### PR TITLE
ci: Add missing permissions for test reports

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -44,6 +44,10 @@ jobs:
   mangrove-js:
     runs-on: ubuntu-latest
 
+    permissions:
+      statuses: write
+      checks: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Build currently fails because the workflow (specifically, `dorny/test-reporter@v1`) does not have permissions to write the test report.