### PR TITLE
Fix/limit order pivot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Next version
 
-# 1.4.10
-
 - fix: wrong pivot when posting limit orders far from the mid price.
 
 # 1.4.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next version
 
+# 1.4.10
+
+- fix: wrong pivot when posting limit orders far from the mid price.
+
 # 1.4.9
 
 - Bump: reliable-event-subscriber to v1.1.24

--- a/src/market.ts
+++ b/src/market.ts
@@ -176,6 +176,7 @@ namespace Market {
     gives: Big;
     volume: Big;
     price: Big | undefined;
+    pivotId?: number;
   };
 
   export type Offer = OfferSlim & {

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -603,7 +603,8 @@ class Trade {
       fillWants,
       wants,
       gives,
-      market
+      market,
+      pivotId
     );
     // if resting order was not posted, result.summary is still undefined.
     return { result, response };
@@ -615,7 +616,8 @@ class Trade {
     fillWants: boolean,
     wants: ethers.BigNumber,
     gives: ethers.BigNumber,
-    market: Market
+    market: Market,
+    pivotId: number
   ) {
     const receipt = await (await response).wait();
 
@@ -642,7 +644,8 @@ class Trade {
       fillWants,
       wants,
       gives,
-      market
+      market,
+      pivotId
     );
 
     if (!this.tradeEventManagement.isOrderResult(result)) {

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -566,8 +566,8 @@ class Trade {
     const { outbound_tkn, inbound_tkn } = market.getOutboundInbound(ba);
     const price = Market.getPrice(
       ba,
-      inbound_tkn.fromUnits(gives),
-      outbound_tkn.fromUnits(wants)
+      /* (maker) gives is takerWants*/ outbound_tkn.fromUnits(wants),
+      /* (maker) wants is takerWants*/ inbound_tkn.fromUnits(gives)
     );
 
     // Find pivot in opposite semibook
@@ -647,8 +647,7 @@ class Trade {
 
     if (!this.tradeEventManagement.isOrderResult(result)) {
       throw Error("mangrove order went wrong");
-    }
-    return result;
+    } else return result;
   }
 
   getRestingOrderParams(params: Market.RestingOrderParams | undefined): {

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -567,7 +567,7 @@ class Trade {
     const price = Market.getPrice(
       ba,
       /* (maker) gives is takerWants*/ outbound_tkn.fromUnits(wants),
-      /* (maker) wants is takerWants*/ inbound_tkn.fromUnits(gives)
+      /* (maker) wants is takerGives*/ inbound_tkn.fromUnits(gives)
     );
 
     // Find pivot in opposite semibook

--- a/src/util/tradeEventManagement.ts
+++ b/src/util/tradeEventManagement.ts
@@ -210,7 +210,8 @@ class TradeEventManagement {
     evt: NewOwnedOfferEvent,
     taker: string,
     currentRestingOrder: Market.OfferSlim | undefined,
-    offerWrites: { ba: Market.BA; offer: Market.OfferSlim }[]
+    offerWrites: { ba: Market.BA; offer: Market.OfferSlim }[],
+    pivotId: number
   ) {
     if (evt.args.owner === taker) {
       ba = ba === "bids" ? "asks" : "bids";
@@ -218,6 +219,9 @@ class TradeEventManagement {
         offerWrites.find(
           (x) => x.ba == ba && x.offer.id === this.#rawIdToId(evt.args.offerId)
         )?.offer ?? currentRestingOrder;
+      if (currentRestingOrder) {
+        currentRestingOrder.pivotId = pivotId;
+      }
     }
     return currentRestingOrder;
   }
@@ -308,7 +312,8 @@ class TradeEventManagement {
       takerGave: ethers.BigNumber
     ) => boolean,
     result: OrderResultWithOptionalSummary,
-    market: Market
+    market: Market,
+    pivotId: number
   ) {
     if (evt.args?.taker && receipt.from !== evt.args.taker) return;
 
@@ -331,7 +336,8 @@ class TradeEventManagement {
           evt as NewOwnedOfferEvent,
           receipt.from,
           result.restingOrder,
-          result.offerWrites
+          result.offerWrites,
+          pivotId
         );
         break;
       }
@@ -388,7 +394,8 @@ class TradeEventManagement {
     fillWants: boolean,
     wants: ethers.BigNumber,
     gives: ethers.BigNumber,
-    market: Market
+    market: Market,
+    pivotId: number
   ) {
     for (const evt of this.getContractEventsFromReceipt(
       receipt,
@@ -400,7 +407,8 @@ class TradeEventManagement {
         ba,
         this.createPartialFillFunc(fillWants, wants, gives),
         result,
-        market
+        market,
+        pivotId
       );
     }
   }

--- a/test/integration/restingOrder.integration.test.ts
+++ b/test/integration/restingOrder.integration.test.ts
@@ -130,12 +130,15 @@ describe("RestingOrder", () => {
       // Fill up bids to verify that pivot is used:
       const meAsLP = await mgv.liquidityProvider(orderLP.market);
       const meProvision = await meAsLP.computeBidProvision();
+      let pivot = 0;
       for (let i = 0; i < 15; i++) {
-        await meAsLP.newBid({
-          wants: 1 + i,
-          gives: 10,
-          fund: meProvision,
-        });
+        pivot = (
+          await meAsLP.newBid({
+            wants: 1 + i,
+            gives: 15,
+            fund: meProvision,
+          })
+        ).id;
       }
 
       const buyPromises = await orderLP.market.buy({
@@ -160,6 +163,14 @@ describe("RestingOrder", () => {
         "Order should have been partially filled"
       );
       assert(orderResult.summary.bounty.eq(0), "No offer should have failed");
+      assert(
+        orderResult.restingOrder
+          ? orderResult.restingOrder.pivotId
+            ? orderResult.restingOrder.pivotId === pivot
+            : false
+          : false,
+        "Pivot not used"
+      );
     });
 
     it("simple resting order, with forceRoutingToMangroveOrder:true", async () => {


### PR DESCRIPTION
This PR fixes a bug that led to a wrong pivot computation when running limit orders.
It also passes `pivotId` to restingOrder results in order to be able to perform regression tests