### PR TITLE
get `LiquidityProvider`  from `OfferLogic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- feat: `LiquidityProvider` getter from an `OfferLogic` instance.
+
 # 1.4.17
 
 - Bump: mangrove-core to v1.5.7

--- a/src/offerLogic.ts
+++ b/src/offerLogic.ts
@@ -2,7 +2,7 @@ import * as ethers from "ethers";
 import { Bigish } from "./types";
 import { typechain } from "./types";
 
-import { Mangrove, Market } from ".";
+import { LiquidityProvider, Mangrove, Market } from ".";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
 import Big from "big.js";
 
@@ -214,6 +214,20 @@ class OfferLogic {
       gasreq,
       opts.gasprice
     );
+  }
+
+  /** Returns a LiquidityProvider with `this` as an underlying offer logic
+   * Note that if `this.contract` is fully compliant with the `ILiquidityProvider` interface, some functions offered by the returned `LiquidityProvider` instance might throw.
+   * @param market the market on which the liqudityProvider will manage offers
+   */
+
+  public async liquidityProvider(market: Market): Promise<LiquidityProvider> {
+    return new LiquidityProvider({
+      mgv: this.mgv,
+      logic: this,
+      gasreq: await this.offerGasreq(),
+      market: market,
+    });
   }
 }
 

--- a/test/integration/offermaker.integration.test.ts
+++ b/test/integration/offermaker.integration.test.ts
@@ -74,7 +74,7 @@ describe("OfferMaker", () => {
         quote: "TokenB",
         bookOptions: { maxOffers: 30 },
       });
-      onchain_lp = await LiquidityProvider.connect(logic, market);
+      onchain_lp = await logic.liquidityProvider(market);
       eoa_lp = await mgv.liquidityProvider(market);
     });
 


### PR DESCRIPTION
This PR reinstates a `LiquidityProvider` getter directly from an `OfferLogic` instance (consistently with the documentation). This introduces two ways to get an LP:
Directly calling via the static `connect` method of the class:
```javascript
const market = await mgv.market({
        base: "TokenA",
        quote: "TokenB",
        bookOptions: { maxOffers: 30 },
      });
onchain_lp = await LiquidityProvider.connect(logic, market);
```

or via an offerLogic:

```javascript
const market = await mgv.market({
        base: "TokenA",
        quote: "TokenB",
        bookOptions: { maxOffers: 30 },
      });
onchain_lp = await logic.liquidityProvider(market);
```
or directly via a Mangrove instance (for EOAs):
```javascript
eoa_lp = await mgv.liquidityProvider(market);
```