### PR TITLE
fix: Disable esbuild minification of identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- fix: Disable esbuild minification of identifiers
+
 # 1.4.22
 
 - fix: do not call getLastBlock if reliable provider does not listen to events

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -35,7 +35,9 @@ const shimOnResolvePlugin = {
 build({
   entryPoints: ["./src/index.ts"],
   bundle: true,
-  minify: true,
+  minifyWhitespace: true,
+  minifySyntax: true,
+  // minifyIdentifiers: true, // Disabled: Breaks certain imports with next.js
   outfile: BrowserBuildPath,
   platform: "browser",
   format: "iife",


### PR DESCRIPTION
The resulting mangrove.js conflicts with certain javascript frameworks.

Minification of whitespace and syntax is kept.