### PR TITLE
fix: infinite approval checks for 2^200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - Bump: mangrove-core to v1.5.10
+- fix: infiniteApproval checks for larger than 2^200, instead of 2^256
 
 # 1.4.24
 

--- a/src/mgvtoken.ts
+++ b/src/mgvtoken.ts
@@ -184,7 +184,7 @@ class MgvToken {
   }
 
   /**
-   * Returns whether allowance of `owner` given to `spender` is infinite.
+   * Returns whether allowance of `owner` given to `spender` is more than 2^200.
    * If `owner` is not specified, defaults to current signer.
    * If `spender` is not specified, defaults to Mangrove instance.
    */
@@ -192,7 +192,7 @@ class MgvToken {
     const rawAllowance = await this.getRawAllowance({
       spender: params.spender,
     });
-    return rawAllowance.eq(ethers.constants.MaxUint256);
+    return rawAllowance.gt(ethers.BigNumber.from(2).pow(200));
   }
 
   private async getRawAllowance(

--- a/test/integration/mgvtoken.integration.test.ts
+++ b/test/integration/mgvtoken.integration.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, it } from "mocha";
 import assert from "assert";
+import { afterEach, beforeEach, describe, it } from "mocha";
 import { Mangrove, ethers } from "../../src";
 
 import { Big } from "big.js";
@@ -46,6 +46,27 @@ describe("MGV Token integration tests suite", () => {
     assert.ok(!(await usdc.allowanceInfinite()));
     await waitForTransaction(usdc.approveMangrove());
     assert.ok(await usdc.allowanceInfinite());
+  });
+
+  it("allowanceInfinite is true if allowance is 2^200 + 1 ", async function () {
+    const usdc = await mgv.token("USDC");
+    assert.ok(!(await usdc.allowanceInfinite()));
+    await waitForTransaction(
+      usdc.approve(
+        mgv.address,
+        Big(2).pow(200).add(1).div(Big(10).pow(usdc.decimals))
+      )
+    );
+    assert.ok(await usdc.allowanceInfinite());
+  });
+
+  it("allowanceInfinite is false if allowance is 2^200 ", async function () {
+    const usdc = await mgv.token("USDC");
+    assert.ok(!(await usdc.allowanceInfinite()));
+    await waitForTransaction(
+      usdc.approve(mgv.address, Big(2).pow(200).div(Big(10).pow(usdc.decimals)))
+    );
+    assert.ok(!(await usdc.allowanceInfinite()));
   });
 
   it("approve sets approved amount", async function () {


### PR DESCRIPTION
This PR changes the infinite approvals check from checking against 2^256, to instead check if the allowance is larger than 2^200. This allows for a broader span of "infinite allowance", this is to handle allowance slowly being used when user do Limit and/or Market orders. 