### PR TITLE
feat(upgrade): Upgrade to newest mangrove-strats

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@ethersproject/experimental": "^5.7.0",
     "@mangrovedao/mangrove-core": "^2.0.0-3",
-    "@mangrovedao/mangrove-strats": "https://github.com/mangrovedao/mangrove-strats.git#commit=01a783f5591f1dd0fcc17f6d0370e1752a02af67",
+    "@mangrovedao/mangrove-strats": "next",
     "@mangrovedao/reliable-event-subscriber": "1.1.29",
     "@types/object-inspect": "^1.8.1",
     "@types/triple-beam": "^1.3.2",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,6 +4,7 @@ import loadedBlockManagerOptionsByNetwork from "./constants/blockManagerOptionsB
 import loadedReliableHttpProviderOptionsByNetwork from "./constants/reliableHttpProviderOptionsByNetwork.json";
 import loadedReliableWebSocketOptionsByNetwork from "./constants/reliableWebSocketOptionsByNetwork.json";
 import loadedKandelConfiguration from "./constants/kandelConfiguration.json";
+import loadedMangroveOrderConfiguration from "./constants/mangroveOrder.json";
 
 import { ethers } from "ethers";
 import Big from "big.js";
@@ -117,10 +118,25 @@ export type PartialKandelConfiguration = PartialKandelAllConfigurationFields & {
   networks?: Record<network, PartialNetworkConfig>;
 };
 
+/** Mangrove order configuration for a specific chain.
+ * @param restingOrderGasreq The gasreq for a resting order using the MangroveOrder contract.
+ * @param takeGasOverhead The overhead of making a market order using the take function on MangroveOrder vs a market order directly on Mangrove.
+ */
+export type MangroveOrderNetworkConfiguration = {
+  restingOrderGasreq: number;
+  takeGasOverhead: number;
+};
+
+export type PartialMangroveOrderConfiguration =
+  Partial<MangroveOrderNetworkConfiguration> & {
+    networks?: Record<network, Partial<MangroveOrderNetworkConfiguration>>;
+  };
+
 export type Configuration = {
   addressesByNetwork: AddressesConfig;
   tokenDefaults: TokenDefaults;
   tokens: Record<tokenSymbol, TokenConfig>;
+  mangroveOrder: PartialMangroveOrderConfiguration;
   reliableEventSubscriber: ReliableEventSubscriberConfig;
   kandel: PartialKandelConfiguration;
 };
@@ -396,6 +412,32 @@ export const reliableEventSubscriberConfiguration = {
   },
 };
 
+/// MANGROVE ORDER
+
+export const mangroveOrderConfiguration = {
+  /** Gets the gasreq for a resting order using the MangroveOrder contract. */
+  getRestingOrderGasreq: (network: string) => {
+    const value =
+      config.mangroveOrder.networks?.[network]?.restingOrderGasreq ??
+      config.mangroveOrder.restingOrderGasreq;
+    if (!value) {
+      throw Error("No restingOrderGasreq configured");
+    }
+    return value;
+  },
+
+  /** Gets the overhead of making a market order using the take function on MangroveOrder vs a market order directly on Mangrove. */
+  getTakeGasOverhead: (network: string) => {
+    const value =
+      config.mangroveOrder.networks?.[network]?.takeGasOverhead ??
+      config.mangroveOrder.takeGasOverhead;
+    if (!value) {
+      throw Error("No takeGasOverhead configured");
+    }
+    return value;
+  },
+};
+
 /// KANDEL
 
 export const kandelConfiguration = {
@@ -451,6 +493,9 @@ export function resetConfiguration(): void {
         >
       ),
     },
+    mangroveOrder: clone(
+      loadedMangroveOrderConfiguration as PartialMangroveOrderConfiguration
+    ),
     kandel: clone(loadedKandelConfiguration as PartialKandelConfiguration),
   };
 
@@ -515,6 +560,7 @@ export const configuration = {
   tokens: tokensConfiguration,
   reliableEventSubscriber: reliableEventSubscriberConfiguration,
   kandel: kandelConfiguration,
+  mangroveOrder: mangroveOrderConfiguration,
   resetConfiguration,
   updateConfiguration,
 };

--- a/src/constants/mangroveOrder.json
+++ b/src/constants/mangroveOrder.json
@@ -1,0 +1,10 @@
+{
+  "takeGasOverhead": 200000,
+  "restingOrderGasreq": 152000,
+  "networks": {
+    "maticmum": {
+      "restingOrderGasreq": 152001,
+      "takeGasOverhead": 200001
+    }
+  }
+}

--- a/src/kandel/kandelInstance.ts
+++ b/src/kandel/kandelInstance.ts
@@ -199,9 +199,8 @@ class KandelInstance {
     return {
       gasprice: params.gasprice,
       gasreq: params.gasreq,
-      stepSize: params.stepSize.toNumber(),
-      // spread: params.,
-      pricePoints: params.pricePoints.toNumber(),
+      stepSize: params.stepSize,
+      pricePoints: params.pricePoints,
     };
   }
 

--- a/src/liquidityProvider.ts
+++ b/src/liquidityProvider.ts
@@ -84,11 +84,13 @@ class LiquidityProvider {
 
   /** Connects the logic to a Market in order to pass market orders. This assumes the underlying contract of offer logic is an ILiquidityProvider.
    * @param offerLogic The offer logic.
+   * @param offerGasreq The gas required for the offer execution on the offer logic.
    * @param p The market to connect to. Can be a Market object or a market descriptor.
    * @returns A LiquidityProvider.
    */
   static async connect(
     offerLogic: OfferLogic,
+    offerGasreq: number,
     p:
       | Market
       | {
@@ -103,14 +105,14 @@ class LiquidityProvider {
         mgv: offerLogic.mgv,
         logic: offerLogic,
         market: p,
-        gasreq: await offerLogic.offerGasreq(),
+        gasreq: offerGasreq,
       });
     } else {
       return new LiquidityProvider({
         mgv: offerLogic.mgv,
         logic: offerLogic,
         market: await offerLogic.mgv.market(p),
-        gasreq: await offerLogic.offerGasreq(),
+        gasreq: offerGasreq,
       });
     }
   }
@@ -129,9 +131,8 @@ class LiquidityProvider {
   ): Promise<Big> {
     const gasreq = opts.gasreq ? opts.gasreq : this.gasreq;
     if (this.logic) {
-      return this.logic.getMissingProvision(this.market, ba, {
+      return this.logic.getMissingProvision(this.market, ba, gasreq, {
         ...opts,
-        gasreq,
       });
     } else {
       const offerInfo = opts.id

--- a/src/market.ts
+++ b/src/market.ts
@@ -26,6 +26,7 @@ import * as TCM from "./types/typechain/Mangrove";
 import TradeEventManagement from "./util/tradeEventManagement";
 import PrettyPrint, { prettyPrintFilter } from "./util/prettyPrint";
 import { MgvLib } from "./types/typechain/Mangrove";
+import configuration from "./configuration";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace Market {
@@ -118,6 +119,7 @@ namespace Market {
   export type RestingOrderParams = {
     provision: Bigish;
     offerId?: number;
+    restingOrderGasreq?: number;
   };
 
   export type CleanParams = {
@@ -332,7 +334,9 @@ class Market {
       await market.#initialize(params.bookOptions);
     }
     const config = await market.config();
-    const gasreq = await params.mgv.orderContract.callStatic["offerGasreq()"]();
+    const gasreq = configuration.mangroveOrder.getRestingOrderGasreq(
+      market.mgv.network.name
+    );
     market.minVolumeAsk = config.asks.density.multiplyUpReadable(
       BigNumber.from(config.asks.offer_gasbase).add(gasreq.toString())
     );

--- a/src/offerMaker.ts
+++ b/src/offerMaker.ts
@@ -1,22 +1,18 @@
 import * as ethers from "ethers";
 import { typechain } from "./types";
 
-const SimpleMakerGasreq = 20000;
-
 /**
  * The OfferMaker class connects to a simple OfferMaker contract
  */
 class OfferMaker {
   static async deploy(
     mgvAddress: string,
-    signer: ethers.Signer,
-    gasreq?: number
+    signer: ethers.Signer
   ): Promise<string> {
     const contract = await new typechain[`OfferMaker__factory`](signer).deploy(
       mgvAddress,
       ethers.constants.AddressZero, // no router
       await signer.getAddress(),
-      gasreq ? gasreq : SimpleMakerGasreq,
       ethers.constants.AddressZero
     );
     await contract.deployTransaction.wait();

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -1045,7 +1045,7 @@ describe("Market integration tests suite", () => {
             } else {
               // Use ethers estimation, if these values are too unstable, then refactor.
               if (forceRouting) {
-                expectedLimit = 126132;
+                expectedLimit = 126278;
               } else {
                 expectedLimit = 43475;
               }
@@ -1500,7 +1500,8 @@ describe("Market integration tests suite", () => {
       inbound_tkn: market.base.address,
       tickSpacing: market.tickSpacing,
     };
-    const gasreq = await mgv.orderContract.callStatic["offerGasreq()"]();
+    // see mangroveOrder.json -> restingOrderGasreq
+    const gasreq = 152000;
     const baseAsOutbound = await mgv.readerContract.minVolume(
       olKeyBaseAsOutbound,
       gasreq

--- a/test/integration/offermaker.integration.test.ts
+++ b/test/integration/offermaker.integration.test.ts
@@ -36,7 +36,7 @@ describe("OfferMaker integration test suite", () => {
       tickSpacing: 1,
       bookOptions: { maxOffers: 30 },
     });
-    onchain_lp = await logic.liquidityProvider(market);
+    onchain_lp = await LiquidityProvider.connect(logic, 20000, market);
     eoa_lp = await mgv.liquidityProvider(market);
     mgvTestUtil.initPollOfTransactionTracking(mgv.provider);
   });

--- a/test/unit/configuration.unit.test.ts
+++ b/test/unit/configuration.unit.test.ts
@@ -70,4 +70,23 @@ describe("Configuration unit tests suite", () => {
     assert.equal(configuration.tokens.getDecimals("TokenA"), 18);
     assert.equal(configuration.tokens.getDecimals("UnknownToken"), undefined);
   });
+
+  it("can read mangroveOrder config", () => {
+    assert.equal(
+      configuration.mangroveOrder.getRestingOrderGasreq("local"),
+      152000
+    );
+    assert.equal(
+      configuration.mangroveOrder.getRestingOrderGasreq("maticmum"),
+      152001
+    );
+    assert.equal(
+      configuration.mangroveOrder.getTakeGasOverhead("local"),
+      200000
+    );
+    assert.equal(
+      configuration.mangroveOrder.getTakeGasOverhead("maticmum"),
+      200001
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,12 +1156,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mangrovedao/mangrove-strats@https://github.com/mangrovedao/mangrove-strats.git#commit=01a783f5591f1dd0fcc17f6d0370e1752a02af67":
-  version: 0.0.2-0
-  resolution: "@mangrovedao/mangrove-strats@https://github.com/mangrovedao/mangrove-strats.git#commit=01a783f5591f1dd0fcc17f6d0370e1752a02af67"
+"@mangrovedao/mangrove-strats@npm:next":
+  version: 0.0.2-3
+  resolution: "@mangrovedao/mangrove-strats@npm:0.0.2-3"
   dependencies:
     "@mangrovedao/mangrove-core": next
-  checksum: 33d84827f37742d85215b7a55947579d24efc3cc845ef0d45adc80bc8dba7b5ea952772dfcfbd37443a2814ad09f1c29ad52b711091b5fcb57f946e0f1e97f81
+  checksum: 32abe70d58d8fc649004ab56c5e717384f091865af2e148f3e1d702604839be45cbf2b203c6dffada006eb8c1df17abb52fbcaf894a9ff76fca2e7087b06b116
   languageName: node
   linkType: hard
 
@@ -1176,7 +1176,7 @@ __metadata:
     "@ethersproject/hardware-wallets": ^5.7.0
     "@ethersproject/providers": ^5.7.2
     "@mangrovedao/mangrove-core": ^2.0.0-3
-    "@mangrovedao/mangrove-strats": "https://github.com/mangrovedao/mangrove-strats.git#commit=01a783f5591f1dd0fcc17f6d0370e1752a02af67"
+    "@mangrovedao/mangrove-strats": next
     "@mangrovedao/reliable-event-subscriber": 1.1.29
     "@typechain/ethers-v5": ^10.2.0
     "@types/big.js": ^6.1.6


### PR DESCRIPTION
Main change is that offerGasreq is removed.

For now, we define the configuration per network, but we will in the future need pass in arbitrary gasreq for arbitrary underlying routers. I suggest we postpone that change till we have the need.

The chosen configuration is as it was defined in solidity prior to this change (except I add 1 for the mumbai values to use in tests)