### PR TITLE
feat: price-tick conversion functions

### DIFF
--- a/src/liquidityProvider.ts
+++ b/src/liquidityProvider.ts
@@ -223,7 +223,7 @@ class LiquidityProvider {
     // deduce price from tick & gives, or deduce tick & gives from volume & price
     if ("tick" in p) {
       tick = ethers.BigNumber.from(p.tick);
-      price = TickLib.priceFromTick(tick);
+      price = tickPriceHelper.priceFromTick(p.ba, market, tick);
       gives = Big(p.gives);
     } else if ("price" in p) {
       price = Big(p.price);

--- a/src/market.ts
+++ b/src/market.ts
@@ -5,7 +5,6 @@ import MgvToken from "./mgvtoken";
 import Semibook from "./semibook";
 import { Bigish, typechain } from "./types";
 import Trade from "./util/trade";
-import TickPriceHelper from "./util/tickPriceHelper";
 
 let canConstructMarket = false;
 
@@ -300,7 +299,6 @@ class Market {
   #bidsSemibook: Semibook | undefined;
   #initClosure?: () => Promise<void>;
   trade: Trade = new Trade();
-  tickPriceHelper: TickPriceHelper = new TickPriceHelper();
   tradeEventManagement: TradeEventManagement = new TradeEventManagement();
   prettyP = new PrettyPrint();
 
@@ -953,26 +951,6 @@ class Market {
     inbound_tkn: MgvToken;
   } {
     return Market.getOutboundInbound(ba, this.base, this.quote);
-  }
-
-  /**
-   * Calculate the price at a given tick.
-   * @param ba bids or asks
-   * @param tick tick to calculate price for
-   * @returns price at tick
-   */
-  priceFromTick(ba: Market.BA, tick: BigNumber): Big {
-    return this.tickPriceHelper.priceFromTick(ba, this, tick);
-  }
-
-  /**
-   * Calculate the tick at a given price.
-   * @param ba bids or asks
-   * @param price price to calculate tick for
-   * @returns tick for price
-   */
-  tickFromPrice(ba: Market.BA, price: Big): BigNumber {
-    return this.tickPriceHelper.tickFromPrice(ba, this, price);
   }
 
   /** Determine which token will be Mangrove's outbound/inbound depending on whether you're working with bids or asks. */

--- a/src/market.ts
+++ b/src/market.ts
@@ -5,6 +5,7 @@ import MgvToken from "./mgvtoken";
 import Semibook from "./semibook";
 import { Bigish, typechain } from "./types";
 import Trade from "./util/trade";
+import TickPriceHelper from "./util/tickPriceHelper";
 
 let canConstructMarket = false;
 
@@ -299,6 +300,7 @@ class Market {
   #bidsSemibook: Semibook | undefined;
   #initClosure?: () => Promise<void>;
   trade: Trade = new Trade();
+  tickPriceHelper: TickPriceHelper = new TickPriceHelper();
   tradeEventManagement: TradeEventManagement = new TradeEventManagement();
   prettyP = new PrettyPrint();
 
@@ -951,6 +953,26 @@ class Market {
     inbound_tkn: MgvToken;
   } {
     return Market.getOutboundInbound(ba, this.base, this.quote);
+  }
+
+  /**
+   * Calculate the price at a given tick.
+   * @param ba bids or asks
+   * @param tick tick to calculate price for
+   * @returns price at tick
+   */
+  priceFromTick(ba: Market.BA, tick: BigNumber): Big {
+    return this.tickPriceHelper.priceFromTick(ba, this, tick);
+  }
+
+  /**
+   * Calculate the tick at a given price.
+   * @param ba bids or asks
+   * @param price price to calculate tick for
+   * @returns tick for price
+   */
+  tickFromPrice(ba: Market.BA, price: Big): BigNumber {
+    return this.tickPriceHelper.tickFromPrice(ba, this, price);
   }
 
   /** Determine which token will be Mangrove's outbound/inbound depending on whether you're working with bids or asks. */

--- a/src/util/tickPriceHelper.ts
+++ b/src/util/tickPriceHelper.ts
@@ -1,0 +1,64 @@
+import { BigNumber } from "ethers";
+import { TickLib } from "./coreCalculations/TickLib";
+import Market from "../market";
+
+import Big from "big.js";
+
+class TickPriceHelper {
+  /**
+   * Calculate the price at a given tick.
+   * @param ba bids or asks
+   * @param tick tick to calculate price for
+   * @returns price at tick
+   */
+  priceFromTick(
+    ba: Market.BA,
+    market: {
+      base: { decimals: number };
+      quote: { decimals: number };
+    },
+    tick: BigNumber
+  ): Big {
+    const priceFromTick = TickLib.priceFromTick(tick);
+    const p = Big(10).pow(
+      Math.abs(market.base.decimals - market.quote.decimals)
+    );
+
+    let priceWithCorrectDecimals: Big;
+    if (ba === "bids") {
+      priceWithCorrectDecimals = priceFromTick.div(p);
+    } else {
+      priceWithCorrectDecimals = priceFromTick.mul(p);
+    }
+    return priceWithCorrectDecimals;
+  }
+
+  /**
+   * Calculate the tick at a given price.
+   * @param ba bids or asks
+   * @param price price to calculate tick for
+   * @returns tick for price
+   */
+  tickFromPrice(
+    ba: Market.BA,
+    market: {
+      base: { decimals: number };
+      quote: { decimals: number };
+    },
+    price: Big
+  ): BigNumber {
+    const p = Big(10).pow(
+      Math.abs(market.base.decimals - market.quote.decimals)
+    );
+
+    let priceAdjustedForDecimals: Big;
+    if (ba === "bids") {
+      priceAdjustedForDecimals = price.mul(p);
+    } else {
+      priceAdjustedForDecimals = price.div(p);
+    }
+    return TickLib.getTickFromPrice(priceAdjustedForDecimals);
+  }
+}
+
+export default TickPriceHelper;

--- a/test/unit/liquidityProvider.unit.test.ts
+++ b/test/unit/liquidityProvider.unit.test.ts
@@ -48,6 +48,28 @@ describe("Liquidity provider unit tests suite", () => {
     assert.deepStrictEqual(tick, BigNumber.from(1));
   });
 
+  it("normalizeOfferParams, with non-equal decimals gives, tick, bids and no funding", async function () {
+    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+      {
+        ba: "bids",
+        tick: 1,
+        gives: 1,
+      },
+      {
+        base: {
+          decimals: 16,
+        },
+        quote: {
+          decimals: 18,
+        },
+      }
+    );
+    assert.equal(price.toNumber(), Big(0.010001).toNumber());
+    assert.deepStrictEqual(gives, Big(1));
+    assert.deepStrictEqual(fund, undefined);
+    assert.deepStrictEqual(tick, BigNumber.from(1));
+  });
+
   it("normalizeOfferParams, with volume and price, as asks", async function () {
     const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
       {

--- a/test/unit/tickPriceHelper.unit.test.ts
+++ b/test/unit/tickPriceHelper.unit.test.ts
@@ -3,7 +3,6 @@ import { Big } from "big.js";
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import { Market } from "../../src";
-import { TickLib } from "../../src/util/coreCalculations/TickLib";
 import { BigNumber } from "ethers";
 import TickPriceHelper from "../../src/util/tickPriceHelper";
 

--- a/test/unit/tickPriceHelper.unit.test.ts
+++ b/test/unit/tickPriceHelper.unit.test.ts
@@ -1,0 +1,238 @@
+import assert from "assert";
+import { Big } from "big.js";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { Market } from "../../src";
+import { TickLib } from "../../src/util/coreCalculations/TickLib";
+import { BigNumber } from "ethers";
+import TickPriceHelper from "../../src/util/tickPriceHelper";
+
+describe("TickPriceHelper unit tests suite", () => {
+  const priceAndTickPairs: {
+    args: {
+      ba: Market.BA;
+      market: { base: { decimals: number }; quote: { decimals: number } };
+    };
+    tick: number;
+    price: Big;
+  }[] = [
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 6 },
+          quote: { decimals: 6 },
+        },
+      },
+      tick: 0,
+      price: Big(1),
+    },
+    {
+      args: {
+        ba: "asks",
+        market: {
+          base: { decimals: 6 },
+          quote: { decimals: 6 },
+        },
+      },
+      tick: 0,
+      price: Big(1),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 6 },
+          quote: { decimals: 18 },
+        },
+      },
+      tick: 0,
+      price: Big("1e-12"),
+    },
+    {
+      args: {
+        ba: "asks",
+        market: {
+          base: { decimals: 6 },
+          quote: { decimals: 18 },
+        },
+      },
+      tick: 0,
+      price: Big("1e12"),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 2 },
+          quote: { decimals: 0 },
+        },
+      },
+      tick: 0,
+      price: Big("0.01"),
+    },
+    {
+      args: {
+        ba: "asks",
+        market: {
+          base: { decimals: 2 },
+          quote: { decimals: 0 },
+        },
+      },
+      tick: 0,
+      price: Big("100"),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 18 },
+          quote: { decimals: 18 },
+        },
+      },
+      tick: 75171,
+      price: Big("1838.534691561"),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 18 },
+          quote: { decimals: 18 },
+        },
+      },
+      tick: -75170,
+      price: Big("0.000543966"),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 0 },
+          quote: { decimals: 18 },
+        },
+      },
+      tick: 414487,
+      price: Big("1.000096034"),
+    },
+    {
+      args: {
+        ba: "bids",
+        market: {
+          base: { decimals: 18 },
+          quote: { decimals: 0 },
+        },
+      },
+      tick: -414487,
+      price: Big("1e-36"),
+    },
+  ];
+
+  const comparisonPrecision = 9;
+
+  describe("priceFromTick", () => {
+    priceAndTickPairs.forEach(({ args, tick, price }) => {
+      it(`returns price=${price} for tick ${tick} with base decimals: ${args.market.base.decimals}, quote decimals: ${args.market.quote.decimals} (${args.ba} semibook)`, async function () {
+        // Arrange
+        const tickPriceHelper = new TickPriceHelper();
+
+        // Act
+        const result = tickPriceHelper.priceFromTick(
+          args.ba,
+          args.market,
+          BigNumber.from(tick)
+        );
+        // Assert
+        assert.ok(
+          result
+            .round(comparisonPrecision)
+            .eq(price.round(comparisonPrecision)),
+          `expected ${price} but got ${result}`
+        );
+      });
+    });
+  });
+
+  describe("tickFromPrice", () => {
+    priceAndTickPairs.forEach(({ args, tick, price }) => {
+      it(`returns tick=${tick} for price ${price} with base decimals: ${args.market.base.decimals}, quote decimals: ${args.market.quote.decimals} (${args.ba} semibook)) `, async function () {
+        // Arrange
+        const tickPriceHelper = new TickPriceHelper();
+
+        // Act
+        const result = tickPriceHelper.tickFromPrice(
+          args.ba,
+          args.market,
+          price
+        );
+        // Assert
+        assert.ok(result.eq(tick), `expected ${tick} but got ${result}`);
+      });
+    });
+  });
+
+  describe("tickFromPrice is inverse of priceFromTick (up to tick-step)", () => {
+    priceAndTickPairs.forEach(({ args, tick }) => {
+      it(`returns tick=${tick} for priceFromTick(..., priceFromTick(..., ${tick}))) with base decimals: ${args.market.base.decimals}, quote decimals: ${args.market.quote.decimals} for ${args.ba} semibook`, async function () {
+        // Arrange
+        const tickPriceHelper = new TickPriceHelper();
+
+        // Act
+        const result = tickPriceHelper.tickFromPrice(
+          args.ba,
+          args.market,
+          tickPriceHelper.priceFromTick(
+            args.ba,
+            args.market,
+            BigNumber.from(tick)
+          )
+        );
+
+        // Assert
+        assert.ok(
+          result.lte(tick + 1) && result.gte(tick - 1),
+          `expected ${tick} to be within 1 of ${result}`
+        );
+      });
+    });
+  });
+
+  describe("priceFromTick is inverse of tickFromPrice (up to tick-step)", () => {
+    priceAndTickPairs.forEach(({ args, price }) => {
+      it(`returns price=${price} for tickFromPrice(..., tickFromPrice(..., ${price}))) with base decimals: ${args.market.base.decimals}, quote decimals: ${args.market.quote.decimals} for ${args.ba} semibook`, async function () {
+        // Arrange
+        const tickPriceHelper = new TickPriceHelper();
+
+        // Act
+        const resultPrice = tickPriceHelper.priceFromTick(
+          args.ba,
+          args.market,
+          tickPriceHelper.tickFromPrice(args.ba, args.market, price)
+        );
+
+        const resultPriceTickPlusOne = tickPriceHelper.priceFromTick(
+          args.ba,
+          args.market,
+          tickPriceHelper.tickFromPrice(args.ba, args.market, price).add(1)
+        );
+
+        const resultPriceTickMinusOne = tickPriceHelper.priceFromTick(
+          args.ba,
+          args.market,
+          tickPriceHelper.tickFromPrice(args.ba, args.market, price).sub(1)
+        );
+
+        const roundedPrice = price.round(comparisonPrecision);
+
+        // Assert
+        assert.ok(
+          resultPriceTickMinusOne
+            .round(comparisonPrecision)
+            .lte(roundedPrice) &&
+            resultPriceTickPlusOne.round(comparisonPrecision).gte(roundedPrice),
+          `expected ${price} to be within one tick-step of ${resultPrice}`
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Collected in util TickPriceHelper, at least for now.

Known outstanding tasks

* tickSpacing is not taken into account
* helpers can be used a few more places (goal: raw TickLib should be used through this lib)
* other helpers wrapping TickLib needs to be added, notable tickFromVolumes