### PR TITLE
ci: Do not run the `check` job if workflow run is cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,12 @@ jobs:
   # see https://github.com/re-actors/alls-green
 
   check:
-    if: always()
+    # NB: We're experimenting with using `!cancelled()` instead of `always()` in an attempt to avoid
+    #     cancelled workflow runs blocking dependabot PR's from merging.
+    #     Workflow runs are often cancelled automatically when a newer run is triggered.
+    #     The problem appears to be that the `check` job runs and fails if the workflow is cancelled.
+    # if: always()
+    if: ${{ !cancelled() }}
 
     needs:
     - file-guard


### PR DESCRIPTION
Experiment using `!cancelled()` instead of `always()` as the condition for the `check` job in an attempt to avoid cancelled workflow runs blocking dependabot PR's from merging.

The problem appears to be that the `check` job runs and fails if the workflow is cancelled. Workflow runs are often cancelled automatically when a newer run is triggered. In this case, the branch protection and dependabot should only consider the latest workflow run, not cancelled ones.