### PR TITLE
fix(addresses): Query for any matching pre-release deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "moize": "^6.1.6",
     "node-cleanup": "^2.1.2",
     "object-inspect": "^1.12.3",
+    "semver": "^7.5.4",
     "triple-beam": "^1.3.0",
     "util": "^0.12.5",
     "yargs": "^17.3.0"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,7 @@ import * as eth from "./eth";
 import clone from "just-clone";
 import deepmerge from "deepmerge";
 import moize from "moize";
+import semver from "semver";
 
 // Make keys optional at all levels of T
 export type RecursivePartial<T> = {
@@ -511,8 +512,9 @@ export function resetConfiguration(): void {
 
 function readMangroveDeploymentAddresses() {
   // Note: Consider how to expose other deployments than the primary
-
-  const mgvCoreVersionPattern = `^${contractPackageVersions["mangrove-core"]}`;
+  const mgvCoreVersionPattern = createContractVersionPattern(
+    contractPackageVersions["mangrove-core"],
+  );
   // Note: Make this configurable?
   const mgvCoreReleasedFilter = undefined; // undefined => released & unreleased, true => released only, false => unreleased only
   const mgvCoreContractsDeployments =
@@ -522,7 +524,10 @@ function readMangroveDeploymentAddresses() {
     });
   readVersionDeploymentsAddresses(mgvCoreContractsDeployments);
 
-  const mgvStratsVersionPattern = `^${contractPackageVersions["mangrove-strats"]}`;
+  // const mgvStratsVersionPattern = `^${contractPackageVersions["mangrove-strats"]}`;
+  const mgvStratsVersionPattern = createContractVersionPattern(
+    contractPackageVersions["mangrove-strats"],
+  );
   // Note: Make this configurable?
   const mgvStratsReleasedFilter = undefined; // undefined => released & unreleased, true => released only, false => unreleased only
   const mgvStratsContractsDeployments =
@@ -531,6 +536,28 @@ function readMangroveDeploymentAddresses() {
       released: mgvStratsReleasedFilter,
     });
   readVersionDeploymentsAddresses(mgvStratsContractsDeployments);
+}
+
+function createContractVersionPattern(contractPackageVersion: string) {
+  const preleaseComponents = semver.prerelease(contractPackageVersion);
+  if (preleaseComponents === null) {
+    // For release versions of contract packages, we match any deployment of the same major version, _excluding_ prereleases.
+    return `^${contractPackageVersion}`;
+  } else {
+    // For pre-release versions of contract packages, we match any deployment of the same major version, _including_ prereleases.
+    // This is achieved by replacing the last prelease component by 0 and using the caret '^' pattern.
+    // This pattern is equivalent to '>= x.y.z-0 < x+1.0.0'.
+    // Examples:
+    //   2.0.0-alpha.1 => ^2.0.0-alpha.0
+    //   2.0.0-4       => ^2.0.0-0
+    const patternPreleaseComponents = [...preleaseComponents];
+    patternPreleaseComponents[patternPreleaseComponents.length - 1] = "0";
+    return `^${semver.major(contractPackageVersion)}.${semver.minor(
+      contractPackageVersion,
+    )}.${semver.patch(contractPackageVersion)}-${patternPreleaseComponents.join(
+      ".",
+    )}`;
+  }
 }
 
 function readVersionDeploymentsAddresses(

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -524,7 +524,6 @@ function readMangroveDeploymentAddresses() {
     });
   readVersionDeploymentsAddresses(mgvCoreContractsDeployments);
 
-  // const mgvStratsVersionPattern = `^${contractPackageVersions["mangrove-strats"]}`;
   const mgvStratsVersionPattern = createContractVersionPattern(
     contractPackageVersions["mangrove-strats"],
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,6 +1326,7 @@ __metadata:
     pinst: ^3.0.0
     prettier: ^3.1.0
     rimraf: ^5.0.1
+    semver: ^7.5.4
     shx: ^0.3.4
     transparent-proxy: ^1.12.1
     triple-beam: ^1.3.0


### PR DESCRIPTION
When querying deployment addresses, we used the pattern `^${contract package dependency version}` in order to get the latest compatible deployment. However, for pre-releases this resulted in SemVer range patterns of the form `x.y.z-n` which only matches the same or _later_ prereleases, not earlier.

For example, this meant that when mangrove.js depends on mangrove-cove 2.0.0-4, deployments of version 2.0.0-3 would not be matched.

This PR changes the logic for prerelease dependencies such that any deployment of the same major version (*including* prereleases) will be matched.