### PR TITLE
feat(kandel); Add tests to measure maxOffersInPopulateChunk, and set configuration

### DIFF
--- a/src/constants/kandelConfiguration.json
+++ b/src/constants/kandelConfiguration.json
@@ -1,15 +1,13 @@
 {
   "gaspriceFactor": 10,
-  "maxOffersInPopulateChunk": 25,
-  "maxOffersInRetractChunk": 25,
+  "maxOffersInPopulateChunk": 198,
+  "maxOffersInRetractChunk": 198,
   "aaveEnabled": false,
   "stepSize": 1,
   "baseQuoteTickOffset": 99,
   "networks": {
     "maticmum": {
       "gasPriceFactor": 10,
-      "maxOffersInPopulateChunk": 40,
-      "maxOffersInRetractChunk": 40,
       "minimumBasePerOfferFactor": 10,
       "minimumQuotePerOfferFactor": 10,
       "markets": {
@@ -48,8 +46,6 @@
       }
     },
     "matic": {
-      "maxOffersInPopulateChunk": 40,
-      "maxOffersInRetractChunk": 40,
       "minimumBasePerOfferFactor": 10,
       "minimumQuotePerOfferFactor": 10,
       "aaveEnabled": true,

--- a/src/kandel/kandelDistributionHelper.ts
+++ b/src/kandel/kandelDistributionHelper.ts
@@ -254,6 +254,7 @@ class KandelDistributionHelper {
    * @param maxOffersInChunk The maximum number of offers in a single chunk.
    * @param middle The middle to split around; typically the index of the first ask in the distribution; if not provided, the midpoint between from and to is used.
    * @returns The chunks.
+   * @dev Since each chunk should contain both an offer and its dual, the returned chunks will have size less than maxOffersInChunk/2.
    */
   public chunkIndicesAroundMiddle(
     from: number,
@@ -261,6 +262,12 @@ class KandelDistributionHelper {
     maxOffersInChunk: number,
     middle?: number,
   ) {
+    if (maxOffersInChunk < 2) {
+      throw Error("maxOffersInChunk must be at least 2");
+    }
+
+    maxOffersInChunk = Math.floor(maxOffersInChunk / 2);
+
     if (middle === undefined) {
       middle = from + Math.floor((to - from) / 2);
     }

--- a/src/util/node.ts
+++ b/src/util/node.ts
@@ -55,6 +55,7 @@ export type inputServerParamsTypeOnly = {
   deploy?: boolean;
   forkUrl?: string;
   forkBlockNumber?: number;
+  gasLimit?: number;
 };
 
 export type inputServerParamsType = inputServerParamsTypeOnly &
@@ -85,6 +86,7 @@ export type partialComputeArgvType = {
   forkUrl?: string;
   "fork-block-number"?: number;
   forkBlockNumber?: number;
+  gasLimit?: number;
   "chain-id"?: number;
   chainId?: number;
   pipe: boolean;
@@ -179,6 +181,11 @@ export const builder = (yargs: yargs.Argv<{}>) => {
       describe: "Pipe all internal anvil/script data to stdout",
       default: false,
       type: "boolean",
+    })
+    .option("gas-limit", {
+      describe: "The block gas limit",
+      type: "number",
+      default: 30_000_000,
     })
     .option("set-multicall-code-if-absent", {
       describe: "Set Multicall code if absent",

--- a/src/util/spawn.ts
+++ b/src/util/spawn.ts
@@ -9,6 +9,7 @@ export type spawnParams = {
   forkBlockNumber?: number;
   host: string;
   port: number | string;
+  gasLimit?: number;
   pipe: boolean;
 };
 
@@ -25,6 +26,10 @@ export const spawn = async (params: spawnParams, mnemonic: string) => {
     params.forkBlockNumber !== undefined
       ? ["--fork-block-number", params.forkBlockNumber.toString()]
       : [];
+  const gasLimitArgs =
+    params.gasLimit !== undefined
+      ? ["--gas-limit", params.gasLimit.toString()]
+      : [];
   const args = [
     "--host",
     params.host,
@@ -37,6 +42,7 @@ export const spawn = async (params: spawnParams, mnemonic: string) => {
   ]
     .concat(chainIdArgs)
     .concat(forkUrlArgs)
+    .concat(gasLimitArgs)
     .concat(blockNumberArgs);
   const anvil = childProcess.spawn("anvil", args);
 

--- a/test/integration/kandel/coreKandelInstance.integration.test.ts
+++ b/test/integration/kandel/coreKandelInstance.integration.test.ts
@@ -779,7 +779,7 @@ describe(`${CoreKandelInstance.prototype.constructor.name} integration tests sui
             await kandel.retractOffers({
               startIndex: 4,
               endIndex: 6,
-              maxOffersInChunk: inChunks ? 1 : 80,
+              maxOffersInChunk: inChunks ? 2 : 80,
               firstAskIndex: 3,
             }),
           );

--- a/test/integration/kandel/maxOffersInChunk.integration.test.ts
+++ b/test/integration/kandel/maxOffersInChunk.integration.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "mocha";
+
+import { KandelStrategies, Mangrove, Market } from "../../../src";
+
+import {
+  waitForTransaction,
+  waitForTransactions,
+} from "../../../src/util/test/mgvIntegrationTestUtil";
+import KandelConfiguration from "../../../src/kandel/kandelConfiguration";
+import assert from "assert";
+import { JsonRpcProvider } from "@ethersproject/providers";
+
+describe("Kandel MaxOffersInChunk verification", () => {
+  let originalGasLimit: number;
+  //Gleaned from https://polygonscan.com/block/ https://mumbai.polygonscan.com/block/ and https://etherscan.io/block/
+  [
+    {
+      gasLimit: 30_000_000,
+      context: "gas-limit for polygon, mumbai, and ethereum",
+    },
+  ].forEach(({ gasLimit, context }) => {
+    let market: Market;
+    let mgv: Mangrove;
+    let configuredMaxOffersInChunk: number;
+    beforeEach(async function () {
+      // Connect mgv
+      mgv = await Mangrove.connect({
+        provider: this.server.url,
+        privateKey: this.accounts.tester.key,
+      });
+      (mgv.provider as any).pollingInterval = 10;
+      const block = await mgv.provider.getBlock("latest");
+      if (!originalGasLimit) {
+        originalGasLimit = block.gasLimit.toNumber();
+      }
+
+      await (mgv.provider as JsonRpcProvider).send("evm_setBlockGasLimit", [
+        gasLimit,
+      ]);
+
+      // Connect market
+      market = await mgv.market({
+        base: "TokenA",
+        quote: "TokenB",
+        tickSpacing: 1,
+      });
+
+      // Mint a lot to have enough
+      await waitForTransaction(
+        market.base.contract.mintTo(
+          this.accounts.tester.address,
+          "1000000000000000000000000",
+        ),
+      );
+      await waitForTransaction(
+        market.quote.contract.mintTo(
+          this.accounts.tester.address,
+          "1000000000000000000000000",
+        ),
+      );
+
+      configuredMaxOffersInChunk =
+        new KandelConfiguration().getMostSpecificConfig(
+          mgv.network.name,
+          market.base.id,
+          market.quote.id,
+        ).maxOffersInRetractChunk;
+    });
+
+    afterEach(async () => {
+      mgv.disconnect();
+      await (mgv.provider as JsonRpcProvider).send("evm_setBlockGasLimit", [
+        originalGasLimit,
+      ]);
+    });
+
+    async function deployAndPopulate(
+      onAave: boolean,
+      saveGasPopulateMode: boolean,
+      maxOffersInChunk: number,
+    ) {
+      const seeder = new KandelStrategies(mgv).seeder;
+      // Deploy kandel
+      const kandel = await (
+        await seeder.sow({
+          market: market,
+          liquiditySharing: false,
+          onAave: onAave,
+        })
+      ).kandelPromise;
+
+      // Make approvals to include deposits in cost
+      await waitForTransactions(await kandel.approveIfHigher());
+
+      // Calculate distribution
+      const distribution =
+        await kandel.geometricGenerator.calculateDistribution({
+          distributionParams: {
+            minPrice: 1,
+            maxPrice: 500,
+            pricePoints: maxOffersInChunk + 10,
+            midPrice: 255,
+            generateFromMid: false,
+            stepSize: 1,
+          },
+          initialAskGives: 1,
+        });
+
+      const { requiredBase, requiredQuote } =
+        distribution.getOfferedVolumeForDistribution();
+
+      // Populate
+      const txs = await kandel.populateGeometricDistribution({
+        distribution,
+        depositBaseAmount: requiredBase,
+        depositQuoteAmount: requiredQuote,
+        populateMode: saveGasPopulateMode ? "saveGas" : "reduceCallData",
+        maxOffersInChunk,
+      });
+      await waitForTransactions(txs);
+    }
+
+    [true, false].forEach((saveGasPopulateMode) => {
+      [true, false].forEach((onAave) => {
+        it(`can create chunks the size of configured for ${context} which has gasLimit=${gasLimit} onAave=${onAave} saveGas=${saveGasPopulateMode}`, async function () {
+          await deployAndPopulate(
+            onAave,
+            saveGasPopulateMode,
+            configuredMaxOffersInChunk,
+          );
+          await deployAndPopulate(
+            onAave,
+            saveGasPopulateMode,
+            configuredMaxOffersInChunk,
+          );
+        });
+
+        it(`can create chunks the size of configured +4 in buffer for ${context} which has gasLimit=${gasLimit} onAave=${onAave} saveGas=${saveGasPopulateMode}`, async function () {
+          await deployAndPopulate(
+            onAave,
+            saveGasPopulateMode,
+            configuredMaxOffersInChunk + 4,
+          );
+          await deployAndPopulate(
+            onAave,
+            saveGasPopulateMode,
+            configuredMaxOffersInChunk + 4,
+          );
+        });
+
+        it(`cannot create chunks the size of configured +10 in buffer for ${context} which has gasLimit=${gasLimit} onAave=${onAave} saveGas=${saveGasPopulateMode}`, async function () {
+          await assert.rejects(
+            () =>
+              deployAndPopulate(
+                onAave,
+                saveGasPopulateMode,
+                configuredMaxOffersInChunk + 10,
+              ),
+            "should revert due to gas limit; otherwise, we are too conservative in the configuration.",
+          );
+        });
+
+        // [...Array(10).keys()]
+        //   .forEach((maxOffersInChunkExtra) => {
+        //     // The following can be used to measure max as a difference to the configured.
+        //     // For values of maxOffersInChunkExtra:
+        //     // 4 works for onAave=true, saveGasPopulateMode=true
+        //     // 8 works for onAave=false, saveGasPopulateMode=true
+        //     // 7 works for onAave=true, saveGasPopulateMode=false
+        //     // 7 works for onAave=false, saveGasPopulateMode=false
+        //     it(`measure maxOffersInChunk for ${context} which has gasLimit=${gasLimit} onAave=${onAave} saveGas=${saveGasPopulateMode} maxOffersInChunkExtra=${maxOffersInChunkExtra}`, async function () {
+        //       await deployAndPopulate(
+        //         onAave,
+        //         saveGasPopulateMode,
+        //         configuredMaxOffersInChunk+maxOffersInChunkExtra,
+        //       );
+        //     });
+        //   });
+      });
+    });
+  });
+});

--- a/test/unit/kandel/generalKandelDistributionHelper.unit.test.ts
+++ b/test/unit/kandel/generalKandelDistributionHelper.unit.test.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 import { Big } from "big.js";
 import { describe, it } from "mocha";
-import KandelDistributionHelper from "../../../src/kandel/kandelDistributionHelper";
 import { KandelDistribution } from "../../../src";
 import {
   assertIsRounded,
@@ -125,92 +124,4 @@ describe(`${GeneralKandelDistributionHelper.prototype.constructor.name} unit tes
       });
     },
   );
-
-  describe(KandelDistributionHelper.prototype.chunkIndices.name, () => {
-    it("can chunk", () => {
-      // Arrange/act
-      const chunks = new KandelDistributionHelper(0, 0).chunkIndices(1, 4, 2);
-
-      // Assert
-      assert.equal(chunks.length, 2);
-      assert.deepStrictEqual(chunks[0], { from: 1, to: 3 });
-      assert.deepStrictEqual(chunks[1], { from: 3, to: 4 });
-    });
-  });
-
-  describe(
-    KandelDistributionHelper.prototype.chunkIndicesAroundMiddle.name,
-    () => {
-      let sut: KandelDistributionHelper;
-      beforeEach(() => {
-        sut = new KandelDistributionHelper(0, 0);
-      });
-
-      [undefined, 2].forEach((middle) => {
-        it(`can chunk an uneven set with middle=${middle}`, () => {
-          // Arrange/act
-          const chunks = sut.chunkIndicesAroundMiddle(1, 4, 2, middle);
-
-          // Assert
-          assert.equal(chunks.length, 2);
-          assert.deepStrictEqual(chunks[0], { from: 1, to: 3 });
-          assert.deepStrictEqual(chunks[1], { from: 3, to: 4 });
-        });
-      });
-
-      it("can chunk an even set", () => {
-        // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 9, 2, 6);
-
-        // Assert
-        assert.equal(chunks.length, 4);
-        assert.deepStrictEqual(chunks[0], { from: 5, to: 7 });
-        assert.deepStrictEqual(chunks[1], { from: 3, to: 5 });
-        assert.deepStrictEqual(chunks[2], { from: 7, to: 9 });
-        assert.deepStrictEqual(chunks[3], { from: 1, to: 3 });
-      });
-
-      it(`works with middle=0`, () => {
-        // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 0);
-
-        // Assert
-        assert.equal(chunks.length, 2);
-        assert.deepStrictEqual(chunks[0], { from: 1, to: 3 });
-        assert.deepStrictEqual(chunks[1], { from: 3, to: 5 });
-      });
-
-      it(`works with middle=4`, () => {
-        // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 4);
-
-        // Assert
-        assert.equal(chunks.length, 2);
-        assert.deepStrictEqual(chunks[0], { from: 3, to: 5 });
-        assert.deepStrictEqual(chunks[1], { from: 1, to: 3 });
-      });
-    },
-  );
-
-  describe(KandelDistributionHelper.prototype.sortByIndex.name, () => {
-    it("sorts", () => {
-      // Arrange
-      const list = [
-        { a: "1", index: 2 },
-        { a: "3", index: 1 },
-        { a: "0", index: 9 },
-      ];
-      const sut = new KandelDistributionHelper(0, 0);
-
-      // Act
-      sut.sortByIndex(list);
-
-      // Assert
-      assert.deepStrictEqual(list, [
-        { a: "3", index: 1 },
-        { a: "1", index: 2 },
-        { a: "0", index: 9 },
-      ]);
-    });
-  });
 });

--- a/test/unit/kandel/kandelDistributionHelper.unit.test.ts
+++ b/test/unit/kandel/kandelDistributionHelper.unit.test.ts
@@ -229,7 +229,7 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
       [undefined, 2].forEach((middle) => {
         it(`can chunk an uneven set with middle=${middle}`, () => {
           // Arrange/act
-          const chunks = sut.chunkIndicesAroundMiddle(1, 4, 2, middle);
+          const chunks = sut.chunkIndicesAroundMiddle(1, 4, 4, middle);
 
           // Assert
           assert.equal(chunks.length, 2);
@@ -240,7 +240,7 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
 
       it("can chunk an even set", () => {
         // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 9, 2, 6);
+        const chunks = sut.chunkIndicesAroundMiddle(1, 9, 4, 6);
 
         // Assert
         assert.equal(chunks.length, 4);
@@ -252,7 +252,7 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
 
       it(`works with middle=0`, () => {
         // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 0);
+        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 4, 0);
 
         // Assert
         assert.equal(chunks.length, 2);
@@ -262,7 +262,7 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
 
       it(`works with middle=4`, () => {
         // Arrange/act
-        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 4);
+        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 4, 4);
 
         // Assert
         assert.equal(chunks.length, 2);


### PR DESCRIPTION
1. Enable setting gas-limit on anvil instance. Default to 30,000,000
2. Add tests to measure maxOffersInPopulateChunk (and set maxOffersInRetractChunk to the same value)
3. Fix call-data reducing populate using too big chunks compared to config.
4. Remove redundant tests due to refactoring.