### PR TITLE
feat: Port Bin part of TickTreeLib and tests

### DIFF
--- a/src/util/coreCalculations/BinLib.ts
+++ b/src/util/coreCalculations/BinLib.ts
@@ -1,0 +1,71 @@
+/*
+ * This is a TypeScript implementation of a subset of Mangrove's TickTreeLib library file. It allows efficient and accurate simulation of Mangrove's tick calculations without RPC calls.
+ * Only the functions required for Tick <-> Bin conversions are ported.
+ *
+ * The implementation follows the original TickTreeLib implementation as closely as possible.
+ * 
+ * The original TickTreeLib implementation can be found here: https://github.com/mangrovedao/mangrove-core/blob/596ed77be48838b10364b7eda1a4f4a4970c0cad/lib/core/TickTreeLib.sol
+ * This is the audited version of Mangrove v2.0.0.
+ * 
+ * NB: Consider using the solidity-math library for easier, more direct, and type-safe
+ *     translation of the Solidity code.
+ */
+
+import { uint } from "./uint";
+import { int } from "./int";
+import * as Int from "./int";
+
+
+// # TickTreeLib.sol
+
+// SPDX-License-Identifier: BUSL-1.1
+// pragma solidity ^0.8.17;
+
+import {MAX_BIN, MIN_BIN} from "./Constants";
+import {Tick} from "./TickLib";
+// import {BitLib} from "@mgv/lib/core/BitLib.sol";
+// import {console2 as csf} from "@mgv/forge-std/console2.sol";
+// import {Local} from "@mgv/src/preprocessed/Local.post.sol";
+
+// Lines 11 - 176 omitted
+
+/* Bins are numbered from MIN_BIN to MAX_BIN (inclusive). Each bin contains the offers at a given price. For a given `tickSpacing`, bins represent the following prices (centered on the central bin): 
+```
+...
+1.0001^-(tickSpacing*2)
+1.0001^-(tickSpacing*1)
+1.0001
+1.0001^(tickSpacing*1)
+1.0001^(tickSpacing*2)
+...
+``` 
+
+There are 4 bins per leaf, `4 * 64` bins per level3, etc. The leaf of a bin is the leaf that holds its first/last offer id. The level3 of a bin is the level3 field above its leaf; the level2 of a bin is the level2 field above its level3, etc. */
+
+/* Globally enable `bin.method(...)` */
+export type Bin = int;
+// using TickTreeLib for Bin global;
+
+// library TickTreeLib {
+
+  export function eq(bin1: Bin, bin2: Bin): boolean {
+    // unchecked {
+      return bin1 == bin2;
+    // }
+  }
+
+  export function inRange(bin: Bin): boolean {
+    // unchecked {
+      return bin.gte(MIN_BIN) && bin.lte(MAX_BIN);
+    // }
+  }
+
+  // Lines 201 - 210 omitted
+
+  /* Returns tick held by the `bin`, given a `tickSpacing`. */
+  export function tick(bin: Bin, tickSpacing: uint): Tick {
+    return Int.mul(bin, int(tickSpacing));
+  }
+
+  // Lines 217 - 586 omitted
+// }

--- a/src/util/coreCalculations/TickLib.ts
+++ b/src/util/coreCalculations/TickLib.ts
@@ -139,7 +139,7 @@ export type Tick = int;
         bin = add(bin,sgt(smod(tick,tickSpacing),0))
       // }
     // }
-    return bin;
+    return int(bin);
   }
 
   /* ## Conversion functions */

--- a/src/util/coreCalculations/int.ts
+++ b/src/util/coreCalculations/int.ts
@@ -81,6 +81,16 @@ export function mul(a: BigNumberish, b: BigNumberish): BigNumber {
   return result;
 }
 
+// a / b for int256.
+export function div(a: BigNumberish, b: BigNumberish): BigNumber {
+  return int(yul.sdiv(int(a), int(b)));
+}
+
+// a % b for int256.
+export function mod(a: BigNumberish, b: BigNumberish): BigNumber {
+  return int(yul.smod(a, b));
+}
+
 // "Cast" a uint256 or int256 to a int256.
 // NB: This assumes a is within the appropriate range.
 export function int(a: BigNumberish): int {

--- a/test/unit/coreCalculations/binLib.unit.test.ts
+++ b/test/unit/coreCalculations/binLib.unit.test.ts
@@ -1,0 +1,213 @@
+/*
+ * This is a TypeScript implementation of a subset of  Mangrove's DynamicBinsTest tests.
+ * Only the tests relevant to Tick <-> Bin conversions are ported.
+ *
+ * The original DynamicBinsTest implementation can be found here: https://github.com/mangrovedao/mangrove-core/blob/596ed77be48838b10364b7eda1a4f4a4970c0cad/test/core/DynamicTicks.t.sol
+ * This is the audited version of Mangrove v2.0.0.
+ */
+
+import { assertEq, assertGe, generateRandomBigNumberRange, generateRandomSignedBigNumberRange } from "./coreCalculationsTestUtils";
+import { BigNumber } from "ethers";
+import { uint } from "../../../src/util/coreCalculations/uint";
+import { int } from "../../../src/util/coreCalculations/int";
+import * as Int from "../../../src/util/coreCalculations/int";
+
+// Literal constants are precomputed for readability and efficiency.
+const _0 = BigNumber.from(0);
+const _1 = BigNumber.from(1);
+
+
+// # DynamicTicks.t.sol
+
+// SPDX-License-Identifier:	AGPL-3.0
+
+// pragma solidity ^0.8.10;
+
+// import "@mgv/test/lib/MangroveTest.sol";
+// import "@mgv/src/core/MgvLib.sol";
+import * as BinLib from "../../../src/util/coreCalculations/BinLib";
+import { Bin } from "../../../src/util/coreCalculations/BinLib";
+import * as TickLib from "../../../src/util/coreCalculations/TickLib";
+// import {DensityLib} from "@mgv/lib/core/DensityLib.sol";
+// import {stdError} from "@mgv/forge-std/StdError.sol";
+// import "@mgv/lib/core/Constants.sol";
+
+// In these tests, the testing contract is the market maker.
+// contract DynamicBinsTest is MangroveTest {
+describe("BinLib unit test suite", () => {
+  // receive() external payable {}
+
+  // TestTaker tkr;
+  // TestMaker mkr;
+  // TestMaker dual_mkr;
+  // address notAdmin;
+
+  // function setUp() public override {
+  //   super.setUp();
+  // }
+
+  generateRandomSignedBigNumberRange(24, 32).map((bin) => {
+  generateRandomBigNumberRange(16, 32).map((tickSpacing) => {
+  it(`test_bin_to_tick(int24 bin: ${bin.toString()}, uint16 tickSpacing: ${tickSpacing.toString()})`, () => {
+    // vm.assume(tickSpacing != 0);
+    if (tickSpacing.eq(_0)) return;
+    // const bin: Bin = Bin.wrap(_bin);
+    assertEq(BinLib.tick(bin, tickSpacing), Int.mul(int(bin), int(uint(tickSpacing))), "wrong bin -> tick");
+  })})});
+
+  generateRandomSignedBigNumberRange(24, 32).map((itick) => {
+  generateRandomBigNumberRange(16, 32).map((_tickSpacing) => {
+  it(`test_tick_to_nearest_bin(int24 itick: ${itick}, uint16 _tickSpacing: ${_tickSpacing})`, () => {
+    // vm.assume(_tickSpacing != 0);
+    if (_tickSpacing.eq(_0)) return;
+    const bin: Bin = TickLib.nearestBin(itick, _tickSpacing);
+    assertGe(BinLib.tick(bin, _tickSpacing), itick, "tick -> bin -> tick must give same or lower bin");
+
+    const tickSpacing: int = int(uint(_tickSpacing));
+    let expectedBin: int = Int.div(itick, tickSpacing);
+    if (itick.gt(0) && !Int.mod(itick, tickSpacing).eq(_0)) {
+      expectedBin = expectedBin.add(_1);
+    }
+    assertEq(bin, expectedBin, "wrong tick -> bin");
+  })})});
+
+  generateRandomSignedBigNumberRange(96, 32).map((tick) => {
+  generateRandomBigNumberRange(256, 32).map((_tickSpacing) => {
+  it(`test_aligned_tick_to_bin(int96 tick, uint _tickSpacing)`, () => {
+    // vm.assume(_tickSpacing != 0);
+    if (_tickSpacing.eq(_0)) return;
+    // vm.assume(tick % int(uint(_tickSpacing)) == 0);
+    if (!Int.mod(tick, int(uint(_tickSpacing))).eq(_0)) return;
+    const bin: Bin = TickLib.nearestBin(tick, _tickSpacing);
+    assertEq(BinLib.tick(bin, _tickSpacing), tick, "aligned tick -> bin -> tick must give same tick");
+  })})});
+
+  // // get a valid tick from a random int24
+  // function boundTick(int24 tick) internal view returns (int24) {
+  //   return int24(bound(tick, MIN_TICK, MAX_TICK));
+  // }
+
+  // // different tickSpacings map to different storage slots
+  // function test_newOffer_store_and_retrieve(uint16 tickSpacing, uint16 tickSpacing2, int24 tick) public {
+  //   vm.assume(tickSpacing != tickSpacing2);
+  //   vm.assume(tickSpacing != 0);
+  //   olKey.tickSpacing = tickSpacing;
+  //   OLKey memory ol2 = OLKey(olKey.outbound_tkn, olKey.inbound_tkn, tickSpacing2);
+  //   mgv.activate(olKey, 0, 100 << 32, 0);
+  //   mgv.activate(ol2, 0, 100 << 32, 0);
+  //   tick = boundTick(tick);
+  //   uint gives = 1 ether;
+
+  //   Tick insertionTick = Tick.wrap(tick).nearestBin(tickSpacing).tick(tickSpacing);
+
+  //   vm.assume(insertionTick.inRange());
+
+  //   uint ofr = mgv.newOfferByTick(olKey, Tick.wrap(tick), gives, 100_000, 30);
+  //   assertTrue(mgv.offers(olKey, ofr).isLive(), "ofr created at tickSpacing but not found there");
+  //   assertFalse(mgv.offers(ol2, ofr).isLive(), "ofr created at tickSpacing but found at tickSpacing2");
+  //   assertEq(mgv.offers(olKey, ofr).tick(), insertionTick, "ofr found at tickSpacing but with wrong ratio");
+  // }
+
+  // // more "tickSpacings do not interfere with one another"
+  // function test_updateOffer_store_and_retrieve(uint16 tickSpacing, uint16 tickSpacing2, int24 tick) public {
+  //   tick = boundTick(tick);
+  //   vm.assume(tickSpacing != tickSpacing2);
+  //   vm.assume(tickSpacing != 0);
+  //   vm.assume(tickSpacing2 != 0);
+  //   olKey.tickSpacing = tickSpacing;
+  //   OLKey memory ol2 = OLKey(olKey.outbound_tkn, olKey.inbound_tkn, tickSpacing2);
+  //   uint gives = 1 ether;
+
+  //   Tick insertionTick = Tick.wrap(tick).nearestBin(tickSpacing).tick(tickSpacing);
+  //   vm.assume(insertionTick.inRange());
+
+  //   mgv.activate(olKey, 0, 100 << 32, 0);
+  //   mgv.activate(ol2, 0, 100 << 32, 0);
+  //   uint ofr = mgv.newOfferByTick(ol2, Tick.wrap(0), gives, 100_000, 30);
+  //   assertTrue(mgv.offers(ol2, ofr).isLive(), "offer created at tickSpacing2 but not found there");
+  //   assertEq(mgv.offers(ol2, ofr).tick(), Tick.wrap(0), "offer found at tickSpacing2 but with wrong ratio");
+  //   assertFalse(mgv.offers(olKey, ofr).isLive(), "offer created at tickSpacing2 but found at tickSpacing");
+
+  //   // test fails if no existing offer
+  //   vm.expectRevert("mgv/updateOffer/unauthorized");
+  //   mgv.updateOfferByTick(olKey, Tick.wrap(tick), gives, 100_000, 30, ofr);
+
+  //   // test offers update does not touch another tickSpacing
+  //   uint ofr2 = mgv.newOfferByTick(olKey, Tick.wrap(1), gives, 100_000, 30);
+  //   assertEq(ofr, ofr2, "tickSpacing and tickSpacing2 seem to shares offer IDs");
+  //   mgv.updateOfferByTick(olKey, Tick.wrap(tick), gives, 100_000, 30, ofr2);
+  //   assertTrue(
+  //     mgv.offers(ol2, ofr).isLive(),
+  //     "creating offer with same ID as ofr in a different tickSpacing seems to have deleted ofr"
+  //   );
+  //   assertEq(
+  //     mgv.offers(ol2, ofr).tick(), Tick.wrap(0), "creating offer with same ID as ofr seems to have changed its ratio"
+  //   );
+  //   assertTrue(mgv.offers(olKey, ofr).isLive(), "offer created at new tickSpacing but not found there");
+  //   assertEq(mgv.offers(olKey, ofr).tick(), insertionTick, "offer found at new tickSpacing but with wrong ratio");
+  // }
+
+  // // the storage of offers depends on the chosen tickSpacing
+  // function test_tickPlacement(uint16 tickSpacing, int24 tick) public {
+  //   olKey.tickSpacing = tickSpacing;
+  //   tick = boundTick(tick);
+  //   vm.assume(tickSpacing != 0);
+  //   uint gives = 1 ether;
+  //   Bin insertionBin = Tick.wrap(tick).nearestBin(tickSpacing);
+  //   Tick insertionTick = insertionBin.tick(tickSpacing);
+  //   vm.assume(insertionTick.inRange());
+
+  //   mgv.activate(olKey, 0, 100 << 32, 0);
+  //   mgv.newOfferByTick(olKey, Tick.wrap(tick), gives, 100_000, 30);
+  //   assertEq(
+  //     mgv.leafs(olKey, insertionBin.leafIndex()).bestNonEmptyBinPos(), insertionBin.posInLeaf(), "wrong pos in leaf"
+  //   );
+  //   assertEq(
+  //     mgv.level3s(olKey, insertionBin.level3Index()).firstOnePosition(),
+  //     insertionBin.posInLevel3(),
+  //     "wrong pos in level3"
+  //   );
+  //   assertEq(
+  //     mgv.level2s(olKey, insertionBin.level2Index()).firstOnePosition(),
+  //     insertionBin.posInLevel2(),
+  //     "wrong pos in level2"
+  //   );
+  //   assertEq(
+  //     mgv.level1s(olKey, insertionBin.level1Index()).firstOnePosition(),
+  //     insertionBin.posInLevel1(),
+  //     "wrong pos in level1"
+  //   );
+  //   assertEq(mgv.root(olKey).firstOnePosition(), insertionBin.posInRoot(), "wrong pos in root");
+  // }
+
+  // function test_id_is_correct(OLKey memory olKey) public {
+  //   assertEq(olKey.hash(), keccak256(abi.encode(olKey)), "id() is hashing incorrect data");
+  // }
+
+  // function test_flipped_is_correct(OLKey memory olKey) public {
+  //   OLKey memory flipped = olKey.flipped();
+  //   assertEq(flipped.inbound_tkn, olKey.outbound_tkn, "flipped() is incorrect");
+  //   assertEq(flipped.outbound_tkn, olKey.inbound_tkn, "flipped() is incorrect");
+  //   assertEq(flipped.tickSpacing, olKey.tickSpacing, "flipped() is incorrect");
+  // }
+
+  // // tick given by maker is normalized and aligned to chosen tickSpacing
+  // function test_insertionTick_normalization(int24 tick, uint16 tickSpacing) public {
+  //   vm.assume(tickSpacing != 0);
+  //   vm.assume(int(tick) % int(uint(tickSpacing)) != 0);
+  //   tick = boundTick(tick);
+  //   Bin insertionBin = Tick.wrap(tick).nearestBin(tickSpacing);
+  //   Tick insertionTick = insertionBin.tick(tickSpacing);
+  //   vm.assume(insertionTick.inRange());
+  //   olKey.tickSpacing = tickSpacing;
+
+  //   mgv.activate(olKey, 0, 100 << 32, 0);
+  //   uint id = mgv.newOfferByTick(olKey, Tick.wrap(tick), 1 ether, 100_00, 30);
+  //   assertEq(mgv.offers(olKey, id).tick(), insertionTick, "recorded tick does not match nearest lower tick");
+  //   assertEq(
+  //     Tick.unwrap(mgv.offers(olKey, id).tick()) % int(uint(tickSpacing)),
+  //     0,
+  //     "recorded tick should be a multiple of tickSpacing"
+  //   );
+  // }
+});

--- a/test/unit/coreCalculations/coreCalculationsTestUtils.ts
+++ b/test/unit/coreCalculations/coreCalculationsTestUtils.ts
@@ -11,6 +11,7 @@ export type Density = BigNumber;
 
 // # Assert functions that mimic Solidity's Foundry's assertions.
 export function assertEq(a: BigNumber | string, b: BigNumberish, err?: string) {
+  console.log("assertEq", a.toString(), b.toString());
   if (typeof a === "string") {
     assert.equal(a, b, err);
   } else {
@@ -33,6 +34,8 @@ export function vm_expectRevert(err: string, f: () => void) {
 
 // # Utility functions for generating pseudo-random values for fuzz testing.
 
+const _neg_1 = BigNumber.from(-1);
+
 const _0 = BigNumber.from(0);
 const _1 = BigNumber.from(1);
 const _2 = BigNumber.from(2);
@@ -53,11 +56,31 @@ export function generateRandomBigNumber(bits: number): BigNumber {
   return randomBigNumber;
 }
 
+export function generateRandomSignedBigNumber(bits: number): BigNumber {
+  let randomBigNumber = generateRandomBigNumber(bits - 1);
+
+  if (Math.random() < 0.5) {
+    randomBigNumber = randomBigNumber.mul(-1);
+  }
+
+  return randomBigNumber;
+}
+
 export function generateRandomBigNumberRange(bits: number, size: number): BigNumber[] {
   // Always include edge cases
   const result: BigNumber[] = [_0, _1, _2.pow(bits).sub(1)];
   for (let i = result.length; i < size; i++) {
     result.push(generateRandomBigNumber(bits));
+  }
+  return result;
+}
+
+export function generateRandomSignedBigNumberRange(bits: number, size: number): BigNumber[] {
+  // Always include edge cases
+  const range = _2.pow(bits - 1);
+  const result: BigNumber[] = [range.mul(-1), _neg_1, _0, _1, range.sub(1)];
+  for (let i = result.length; i < size; i++) {
+    result.push(generateRandomSignedBigNumber(bits));
   }
   return result;
 }


### PR DESCRIPTION
For testing `TickLib.nearestBin` and for later handling of tick spaces, the `TickTreeLib.tick(bin, tickSpacing)` function is needed. The rest of `TickTreeLib` is not needed, so a partial port has been and named `BinLib`.

The tick <-> bin conversion tests from `DynamicBinsTest` has also been ported.

The test uncovered a bug in the port of `nearestBin`: After the Yul assembly code (which only deals with words, ie uints), the bin should be converted to its `int` BigNumber representation, but this wasn't done. This is implicit in Solidity, but must be handled explicitly in the ported code.
This has now been fixed.