### PR TITLE
feat: Market API simplification & fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next version
 
+- feat: `Market.Key` type introduced to identify markets (base, quote, tick spacing) in the API.
+- feat!: `Mangrove.openMarkets` no longer connects to all markets, but returns a list of `Market.Key`s, optionally with the relevant offer list configuration attached to each. This is identical to the previous `Mangrove.openMarketsData` which has been removed.
+- feat!: Use of `Big(ish)` for `tickSpacing` in a few places has been replaced by `BigNumber(ish)` for consistency with the rest of the API.
+
 # 2.0.0-10
 
 # 2.0.0-9

--- a/src/kandel/coreKandelInstance.ts
+++ b/src/kandel/coreKandelInstance.ts
@@ -25,7 +25,7 @@ export type MarketOrMarketFactory =
   | ((
       baseAddress: string,
       quoteAddress: string,
-      tickSpacing: Bigish,
+      tickSpacing: ethers.BigNumberish,
     ) => Promise<Market>);
 
 /**

--- a/src/kandelStrategies.ts
+++ b/src/kandelStrategies.ts
@@ -5,12 +5,12 @@ import Market from "./market";
 import KandelDistributionHelper from "./kandel/kandelDistributionHelper";
 import GeometricKandelDistributionGenerator from "./kandel/geometricKandel/geometricKandelDistributionGenerator";
 import KandelConfiguration from "./kandel/kandelConfiguration";
-import { Bigish } from "./types";
 import GeometricKandelLib from "./kandel/geometricKandel/geometricKandelLib";
 import GeometricKandelInstance from "./kandel/geometricKandel/geometricKandelInstance";
 import GeometricKandelDistributionHelper from "./kandel/geometricKandel/geometricKandelDistributionHelper";
 import GeneralKandelDistributionHelper from "./kandel/generalKandelDistributionHelper";
 import configuration from "./configuration";
+import { BigNumberish } from "ethers";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace KandelStrategies {}
@@ -53,12 +53,16 @@ class KandelStrategies {
       | ((
           baseAddress: string,
           quoteAddress: string,
-          tickSpacing: Bigish,
+          tickSpacing: BigNumberish,
         ) => Promise<Market>);
   }) {
     const market =
       params.market ??
-      ((baseAddress: string, quoteAddress: string, tickSpacing: Bigish) => {
+      ((
+        baseAddress: string,
+        quoteAddress: string,
+        tickSpacing: BigNumberish,
+      ) => {
         const baseToken = configuration.tokens.getTokenIdFromAddress(
           baseAddress,
           this.mgv.network.name,

--- a/src/liquidityProvider.ts
+++ b/src/liquidityProvider.ts
@@ -95,7 +95,7 @@ class LiquidityProvider {
       | {
           base: string;
           quote: string;
-          tickSpacing: Bigish;
+          tickSpacing: ethers.BigNumberish;
           bookOptions?: Market.BookOptions;
         },
   ): Promise<LiquidityProvider> {

--- a/test/integration/mangrove.integration.test.ts
+++ b/test/integration/mangrove.integration.test.ts
@@ -95,7 +95,7 @@ describe("Mangrove integration tests suite", function () {
         tkn1: mgv.getTokenAddress("TokenB"),
         tickSpacing: 1,
       });
-      let marketData = await mgv.openMarketsData();
+      let marketData = await mgv.openMarkets();
       const tokenAData = {
         address: mgv.getTokenAddress("TokenA"),
         decimals: 18,
@@ -118,7 +118,7 @@ describe("Mangrove integration tests suite", function () {
       assert.deepEqual(tokenToData(marketData[0].quote), tokenBData);
 
       configuration.tokens.setCashness("TokenA", 1000000);
-      marketData = await mgv.openMarketsData();
+      marketData = await mgv.openMarkets();
 
       assert.deepEqual(tokenToData(marketData[0].base), tokenBData);
       assert.deepEqual(tokenToData(marketData[0].quote), tokenAData);


### PR DESCRIPTION
- `Market.Key` type introduced to identify markets (base, quote, tick spacing) in the API.
- Use of `Big(ish)` for `tickSpacing` in a few places has been replaced by `BigNumber(ish)` for consistency with the rest of the API.
- `Mangrove.openMarkets` no longer connects to all markets, but returns a list of `Market.Key`s, optionally with the relevant offer list configuration attached to each. This is identical to the previous `Mangrove.openMarketsData` which has been removed.
