### PR TITLE
fix: Semibook cache consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - feat: Thread tickSpacing through code to be able to use it in tick/price calculations.
 - fix: Change tick and tickSpacing to be number type
 - feat!: Rename tick parameters of 'Market.simulateGas' and 'Semibook.simulateMarketOrder' to 'maxTick'.
+- fix: Semibook now maintains consistency. After the upgrade to Mangrove v2, the cache could become inconsistent as it was not ensuring that added offers were an extension of the prefix held in the case.
+- feat: Semibook cache now holds complete tick bins: If one offer with a given tick is in the cache, all offers with that tick is in the cache.
+- feat!: The `maxOffers` option in `CacheContentOptions` has been replaced with a new option: `targetNumberOfTicks`. When loading from chain, the cache will load until at least this number of ticks is in the cache. The default is `Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS`.
+- feat!: A new default value `Semibook.DEFAULT_CHUNK_SIZE` has been introduced for `CacheContentOptions.chunkSize`.
 
 # 2.0.0-12
 

--- a/src/cli/commands/printCmd.ts
+++ b/src/cli/commands/printCmd.ts
@@ -12,7 +12,7 @@ export const builder = (yargs: yargs.Argv) => {
     .positional("base", { type: "string", demandOption: true })
     .positional("quote", { type: "string", demandOption: true })
     .positional("tickSpacing", { type: "number", demandOption: true })
-    .option("maxOffers", { type: "number", default: 10 })
+    .option("targetNumberOfTicks", { type: "number", default: 10 })
     .option("ba", { choices: ["asks", "bids"] })
     .option("nodeUrl", { type: "string", demandOption: true });
 };
@@ -26,7 +26,7 @@ export async function handler(argvOrPromiseArgv: Arguments): Promise<void> {
     base: argv.base,
     quote: argv.quote,
     tickSpacing: argv.tickSpacing,
-    bookOptions: { maxOffers: argv.maxOffers },
+    bookOptions: { targetNumberOfTicks: argv.targetNumberOfTicks },
   });
   const { asks, bids } = market.getBook();
 

--- a/src/cli/commands/retractCmd.ts
+++ b/src/cli/commands/retractCmd.ts
@@ -34,7 +34,7 @@ export async function handler(argvOrPromiseArgv: Arguments): Promise<void> {
     base: argv.base,
     quote: argv.quote,
     tickSpacing: argv.tickSpacing,
-    bookOptions: { maxOffers: 200 },
+    bookOptions: { targetNumberOfTicks: 200 },
   });
 
   const makerAddress = wallet.address;

--- a/src/mangroveEventSubscriber.ts
+++ b/src/mangroveEventSubscriber.ts
@@ -32,11 +32,13 @@ class MangroveEventSubscriber extends LogSubscriber<Market.BookSubscriptionEvent
   }
 
   static optionsIdentifier(options: Semibook.Options) {
-    return `${"maxOffers" in options ? options.maxOffers : "undefined"}_${
-      "desiredPrice" in options ? options.desiredPrice : "undefined"
-    }_${"desiredVolume" in options ? options.desiredVolume : "undefined"}_${
-      options.chunkSize
-    }`;
+    return `${
+      "targetNumberOfTicks" in options
+        ? options.targetNumberOfTicks
+        : "undefined"
+    }_${"desiredPrice" in options ? options.desiredPrice : "undefined"}_${
+      "desiredVolume" in options ? options.desiredVolume : "undefined"
+    }_${options.chunkSize}`;
   }
 
   public async enableSubscriptions() {

--- a/src/market.ts
+++ b/src/market.ts
@@ -23,7 +23,8 @@ let canConstructMarket = false;
 const MAX_MARKET_ORDER_GAS = 10000000;
 
 export const bookOptsDefault: Market.BookOptions = {
-  maxOffers: Semibook.DEFAULT_MAX_OFFERS,
+  targetNumberOfTicks: Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS,
+  chunkSize: Semibook.DEFAULT_CHUNK_SIZE,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -200,16 +201,18 @@ namespace Market {
   /**
    * Options that specify what the cache fetches and retains.
    *
-   * `maxOffers`, `desiredPrice`, and `desiredVolume` are mutually exclusive.
-   * If none of these are specified, the default is `maxOffers` = `Semibook.DEFAULT_MAX_OFFERS`.
+   * `targetNumberOfTicks`, `desiredPrice`, and `desiredVolume` are mutually exclusive.
+   * If none of these are specified, the default is `targetNumberOfTicks` = `Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS`.
    */
   export type CacheContentsOptions =
     | {
-        /** The maximum number of offers to store in the cache.
+        /** The number of ticks the cache should ideally hold.
          *
-         * `maxOffers, `desiredPrice`, and `desiredVolume` are mutually exclusive.
+         * When loading from chain, the cache will load until at least this number of ticks is in the cache.
+         *
+         * `targetNumberOfTicks, `desiredPrice`, and `desiredVolume` are mutually exclusive.
          */
-        maxOffers?: number;
+        targetNumberOfTicks?: number;
       }
     | {
         /** The price that is expected to be used in calls to the market.
@@ -230,7 +233,7 @@ namespace Market {
   export type BookOptions = CacheContentsOptions & {
     /** The number of offers to fetch in one call.
      *
-     * Defaults to `maxOffers` if it is set and positive; Otherwise `Semibook.DEFAULT_MAX_OFFERS` is used. */
+     * Defaults to `Semibook.DEFAULT_CHUNK_SIZE`. */
     chunkSize?: number;
   };
 
@@ -470,9 +473,9 @@ class Market {
           desiredPrice: opts.desiredPrice,
           chunkSize: opts.chunkSize,
         };
-      } else if ("maxOffers" in opts) {
+      } else if ("targetNumberOfTicks" in opts) {
         return {
-          maxOffers: opts.maxOffers,
+          targetNumberOfTicks: opts.targetNumberOfTicks,
           chunkSize: opts.chunkSize,
         };
       } else {

--- a/src/semibook.ts
+++ b/src/semibook.ts
@@ -60,16 +60,18 @@ namespace Semibook {
   /**
    * Options that specify what the cache fetches and retains.
    *
-   * `maxOffers`, `desiredPrice`, and `desiredVolume` are mutually exclusive.
-   * If none of these are specified, the default is `maxOffers` = `Semibook.DEFAULT_MAX_OFFERS`.
+   * `targetNumberOfTicks`, `desiredPrice`, and `desiredVolume` are mutually exclusive.
+   * If none of these are specified, the default is `targetNumberOfTicks` = `Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS`.
    */
   export type CacheContentsOptions =
     | {
-        /** The maximum number of offers to store in the cache.
+        /** The number of ticks the cache should ideally hold.
          *
-         * `maxOffers, `desiredPrice`, and `desiredVolume` are mutually exclusive.
+         * When loading from chain, the cache will load until at least this number of ticks is in the cache.
+         *
+         * `targetNumberOfTicks, `desiredPrice`, and `desiredVolume` are mutually exclusive.
          */
-        maxOffers?: number;
+        targetNumberOfTicks?: number;
       }
     | {
         /** The price that is expected to be used in calls to the market.
@@ -90,7 +92,7 @@ namespace Semibook {
   export type Options = CacheContentsOptions & {
     /** The number of offers to fetch in one call.
      *
-     * Defaults to `maxOffers` if it is set and positive; Otherwise `Semibook.DEFAULT_MAX_OFFERS` is used. */
+     * Defaults to `Semibook.DEFAULT_CHUNK_SIZE`. */
     chunkSize?: number;
   };
 
@@ -99,9 +101,9 @@ namespace Semibook {
    */
   export type ResolvedOptions = (
     | {
-        /** The maximum number of offers to store in the cache.
+        /** The maximum number of ticks to store in the cache.
          */
-        maxOffers: number;
+        targetNumberOfTicks: number;
       }
     | {
         /** The price that is expected to be used in calls to the market.
@@ -152,21 +154,37 @@ namespace Semibook {
    */
   export type Bin = {
     tick: number;
+    offerCount: number;
     firstOfferId: number;
     lastOfferId: number;
     prev: Bin | undefined;
     next: Bin | undefined;
   };
 
+  /**
+   * The cache at a given block. It holds a prefix of the on-chain offer list: All offers with a tick less than or equal to a max tick.
+   *
+   * Must only be modified using the methods in `SemibookCacheOperations` to ensure cache consistency.
+   *
+   * Invariants:
+   * - tick in binCache                                                   =>  all offers for that tick are in offerCache and there is at least one such offer
+   * - tick1 in binCache && tick2 < tick1 && ∃offer: offer.tick == tick2  =>  tick2 in binCache
+   * - bestBinInCache.tick != undefined                                   =>  bestBinInCache.tick is the best tick in the offer list
+   * - isComplete                                                         =>  all offers in the offer list are in the cache
+   */
   export type State = {
-    offerCache: Map<number, Market.Offer>; // offer ID -> Offer. NB: Modify only via #insertOffer and #removeOffer to ensure cache consistency
-    binCache: Map<number, Semibook.Bin>; // tick -> Bin. NB: Modify only via #insertOffer and #removeOffer to ensure cache consistency
+    offerCache: Map<number, Market.Offer>; // offer ID -> Offer
+    binCache: Map<number, Semibook.Bin>; // tick -> Bin
     bestBinInCache: Semibook.Bin | undefined; // best/first bin in the offer list iff #binCache is non-empty
     worstBinInCache: Semibook.Bin | undefined; // worst/last bin in #binCache
+    isComplete: boolean; // whether the cache contains all offers in the offer list
   };
 
   export type FetchOfferListResult = Result<
-    Market.Offer[],
+    {
+      bins: Map<number, Market.Offer[]>; // tick -> offers
+      endOfListReached: boolean; // whether the end of the offer list was reached
+    },
     LogSubscriber.Error
   >;
 
@@ -185,12 +203,12 @@ namespace Semibook {
  * - Prices are in terms of quote tokens per base token
  * - Volumes are in terms of base tokens
  */
-// TODO: Document invariants
 class Semibook
   extends StateLogSubscriber<Semibook.State, Market.BookSubscriptionEvent>
   implements Iterable<Market.Offer>
 {
-  static readonly DEFAULT_MAX_OFFERS = 50;
+  static readonly DEFAULT_TARGET_NUMBER_OF_TICKS = 50;
+  static readonly DEFAULT_CHUNK_SIZE = 50;
 
   readonly ba: Market.BA;
   readonly market: Market;
@@ -247,6 +265,7 @@ class Semibook
     for (const [tick, bin] of state.binCache) {
       const clonedBin = {
         tick: bin.tick,
+        offerCount: bin.offerCount,
         firstOfferId: bin.firstOfferId,
         lastOfferId: bin.lastOfferId,
         prev: undefined,
@@ -255,7 +274,6 @@ class Semibook
       clonedBinCache.set(tick, clonedBin);
     }
 
-    // Manually set the prev, next, best, and worst Bin references
     for (const [tick, clonedBin] of clonedBinCache) {
       const bin = state.binCache.get(tick)!;
       clonedBin.prev =
@@ -278,6 +296,7 @@ class Semibook
       binCache: clonedBinCache,
       bestBinInCache: clonedBestBinInCache,
       worstBinInCache: clonedWorstBinInCache,
+      isComplete: state.isComplete,
     };
   }
 
@@ -305,7 +324,7 @@ class Semibook
       throw new Error(result.error); // this is done to not break legacy code
     }
 
-    return result.ok;
+    return Array.from(result.ok.bins.values()).flatMap((offers) => offers);
   }
 
   /** Returns struct containing offer details in the current offer list */
@@ -342,7 +361,7 @@ class Semibook
   /**
    * Return config local to a semibook.
    * Notes:
-   * Amounts are converted to plain numbers.
+   * Amounts are converted to human readable numbers.
    * density is converted to public token units per gas used
    * fee *remains* in basis points of the token being bought
    */
@@ -427,7 +446,7 @@ class Semibook
    * will return the volume you will be able to receive if selling up to 10 quote
    * at a max. price of 2 quote/base, i.e. a min. "price" of 1/2 = 0.5 base/quote.
    *
-   * The returned `givenResidue` is how much of the given token that cannot be
+   * The returned `remainingFillVolume` is how much of the given token that cannot be
    * traded due to insufficient volume on the book / price becoming bad.
    */
   async estimateVolume(
@@ -584,35 +603,49 @@ class Semibook
   }
 
   async getMaxGasReq(): Promise<number | undefined> {
-    // If a cache max size is set, then we look at those; otherwise, allow going to the chain to fetch data for the semibook.
-    const maxOffers =
-      "maxOffers" in this.options
-        ? this.options.maxOffers
-        : Semibook.DEFAULT_MAX_OFFERS;
-    let offerNum = 0;
-    // TODO: The implementation of the following predicate is work-in-progress
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const countOfferForMaxGasPredicate = (_o: Market.Offer) => {
-      offerNum++;
-      return true;
-    };
+    // Check at most the target number of ticks that the cache should hold
+    const targetNumberOfTicks =
+      "targetNumberOfTicks" in this.options
+        ? this.options.targetNumberOfTicks
+        : Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS;
 
     const state = this.getLatestState();
-    const result = await this.#foldLeftUntil<{ maxGasReq?: number }>(
+    const result = await this.#foldLeftUntil<{
+      maxGasReq?: number;
+      ticksSeen: number;
+      lastSeenTick?: number;
+      offersSeenInTick: number;
+    }>(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.lastSeenEventBlock!,
       state,
-      { maxGasReq: undefined },
-      () => {
-        return offerNum >= maxOffers;
+      {
+        maxGasReq: undefined,
+        ticksSeen: 0,
+        lastSeenTick: undefined,
+        offersSeenInTick: 0,
+      },
+      (acc) => {
+        // Stop if we've seen targetNumberOfTicks ticks and we've seen all offers in the last tick
+        return (
+          acc.ticksSeen >= targetNumberOfTicks &&
+          acc.offersSeenInTick ===
+            state.binCache.get(acc.lastSeenTick!)?.offerCount
+        );
       },
       (cur, acc) => {
-        if (countOfferForMaxGasPredicate(cur)) {
-          if (acc.maxGasReq === undefined) {
-            acc.maxGasReq = cur.gasreq;
-          } else {
-            acc.maxGasReq = Math.max(cur.gasreq, acc.maxGasReq);
-          }
+        if (acc.maxGasReq === undefined) {
+          acc.maxGasReq = cur.gasreq;
+        } else {
+          acc.maxGasReq = Math.max(cur.gasreq, acc.maxGasReq);
+        }
+
+        if (cur.tick !== acc.lastSeenTick) {
+          acc.ticksSeen++;
+          acc.lastSeenTick = cur.tick;
+          acc.offersSeenInTick = 1;
+        } else {
+          acc.offersSeenInTick++;
         }
 
         return acc;
@@ -645,19 +678,12 @@ class Semibook
       return accumulator;
     }
 
-    // Are we certain to be at the end of the book?
-    const isCacheCertainlyComplete =
-      state.worstBinInCache !== undefined &&
-      this.#cacheOperations.getOfferFromCacheOrFail(
-        state,
-        state.worstBinInCache.lastOfferId,
-      ).next === undefined;
-
-    if (isCacheCertainlyComplete) {
+    if (state.isComplete) {
       return accumulator;
     }
 
     // Either the offer list is empty or the cache is insufficient.
+    // The cache is insufficient, possibly because the offer list doesn't have more offers.
     // Lock the cache as we are going to fetch more offers and put them in the cache
     return await this.cacheLock.runExclusive(async () => {
       // When the lock has been obtained, the cache may have changed,
@@ -673,48 +699,39 @@ class Semibook
         return accumulator;
       }
 
-      // Are we certain to be at the end of the book?
-      const isCacheCertainlyComplete =
-        state.worstBinInCache !== undefined &&
-        this.#cacheOperations.getOfferFromCacheOrFail(
-          state,
-          state.worstBinInCache.lastOfferId,
-        ).next === undefined;
-      if (isCacheCertainlyComplete) {
+      if (state.isComplete) {
         return accumulator;
       }
 
-      // Either the offer list is still empty or the cache is still insufficient.
-      // Try to fetch more offers to complete the fold
-      const nextId =
+      // The cache is insufficient and we don't know if the offer list has more offers.
+      // Try to fetch more offers to complete the fold.
+      // If the cache is empty, start from the best offer.
+      // If the cache is non-empty, start from the last offer in the cache as we don't know the id of the following offer.
+      const { fromId, ignoreFirstOffer } =
         state.worstBinInCache === undefined
-          ? undefined
-          : this.#cacheOperations.getOfferFromCacheOrFail(
-              state,
-              state.worstBinInCache.lastOfferId,
-            ).next;
-
+          ? { fromId: undefined, ignoreFirstOffer: false }
+          : {
+              fromId: state.worstBinInCache.lastOfferId,
+              ignoreFirstOffer: true,
+            };
       await this.#fetchOfferListPrefixUntil(
         block,
-        nextId,
+        fromId,
         this.options.chunkSize,
-        (chunk: Market.Offer[]) => {
-          for (const offer of chunk) {
-            // We try to insert all the fetched offers in case the cache is not at max size
-            this.#cacheOperations.insertOffer(state, offer, {
-              maxOffers:
-                "maxOffers" in this.options
-                  ? this.options.maxOffers
-                  : undefined,
-            });
-
-            // Only apply op f stop condition is _not_ met
-            if (!stopCondition(accumulator)) {
+        (tick, bin: Market.Offer[]) => {
+          // Insert the fetched bin into the cache
+          this.#cacheOperations.insertCompleteBin(state, bin);
+          for (const offer of bin) {
+            // Only apply op if stop condition is _not_ met
+            if (stopCondition(accumulator)) {
+              break;
+            } else {
               accumulator = op(offer, accumulator);
             }
           }
           return stopCondition(accumulator);
         },
+        ignoreFirstOffer,
       );
 
       return accumulator;
@@ -772,36 +789,23 @@ class Semibook
       if (result.error) {
         return { error: result.error, ok: undefined };
       }
-
-      const offers = result.ok;
-
-      if (offers.length > 0) {
-        const state: Semibook.State = {
-          offerCache: new Map(),
-          binCache: new Map(),
-          bestBinInCache: undefined,
-          worstBinInCache: undefined,
-        };
-
-        for (const offer of offers) {
-          this.#cacheOperations.insertOffer(state, offer, {
-            maxOffers:
-              "maxOffers" in this.options ? this.options.maxOffers : undefined,
-          });
-        }
-
-        return {
-          error: undefined,
-          ok: state,
-        };
-      }
+      const { bins, endOfListReached } = result.ok;
 
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
         bestBinInCache: undefined,
         worstBinInCache: undefined,
+        isComplete: false,
       };
+
+      for (const binOffers of bins.values()) {
+        this.#cacheOperations.insertCompleteBin(state, binOffers);
+      }
+
+      if (endOfListReached) {
+        this.#cacheOperations.markComplete(state);
+      }
 
       return {
         error: undefined,
@@ -823,7 +827,6 @@ class Semibook
 
     let offer: Market.Offer;
     let removedOffer: Market.Offer | undefined;
-    let next: number | undefined;
 
     const { outbound_tkn, inbound_tkn } = this.market.getOutboundInbound(
       this.ba,
@@ -831,44 +834,31 @@ class Semibook
 
     switch (event.name) {
       case "OfferWrite": {
-        // We ignore the return value here because the offer may have been outside the local
-        // cache, but may now enter the local cache due to its new price.
         const id = Semibook.rawIdToId(event.args.id);
-
         if (id === undefined)
           throw new Error("Received OfferWrite event with id = 0");
-        let expectOfferInsertionInCache = true;
-        this.#cacheOperations.removeOffer(state, id);
 
-        /* After removing the offer (a noop if the offer was not in local cache), we reinsert it.
-         * The offer comes with id of its prev. If prev does not exist in cache, we skip
-         * the event. Note that we still want to remove the offer from the cache.
-         * If the prev exists, we take the prev's next as the offer's next.
-         * Whether that next exists in the cache or not is irrelevant.
-         */
+        // First, remove the offer from the cache if it is already there
+        // since only OfferWrite is emitted on offer update.
+        this.#cacheOperations.removeOfferDueToEvent(state, id, true);
+
+        // After removing the offer (a noop if the offer was not in local cache), we try to reinsert it.
         offer = {
           offer_gasbase: this.#offer_gasbase,
-          next: next,
-          prev: undefined,
+          next: undefined, // offers are always inserted at the end of the list
+          prev: undefined, // prev will be set when the offer is inserted into the cache iff the previous offer exists in the cache
           ...this.rawOfferSlimToOfferSlim(event.args),
         };
 
-        if (
-          !this.#cacheOperations.insertOffer(state, offer, {
-            maxOffers:
-              "maxOffers" in this.options ? this.options.maxOffers : undefined,
-          })
-        ) {
-          // Offer was not inserted
-          expectOfferInsertionInCache = false;
-        }
+        const offerInsertedInCache =
+          this.#cacheOperations.insertOfferDueToEvent(state, offer);
 
         Array.from(this.#eventListeners.keys()).forEach(
           (listener) =>
             void listener({
               cbArg: {
                 type: event.name,
-                offer: expectOfferInsertionInCache ? offer : undefined,
+                offer: offerInsertedInCache ? offer : undefined, // offer is undefined if the offer was not inserted into the cache
                 offerId: id,
                 ba: this.ba,
               },
@@ -931,7 +921,11 @@ class Semibook
         const id = Semibook.rawIdToId(event.args.id);
         if (id === undefined)
           throw new Error("Received OfferRetract event with id = 0");
-        removedOffer = this.#cacheOperations.removeOffer(state, id);
+        removedOffer = this.#cacheOperations.removeOfferDueToEvent(
+          state,
+          id,
+          true,
+        );
         Array.from(this.#eventListeners.keys()).forEach(
           (listener) =>
             void listener({
@@ -982,7 +976,7 @@ class Semibook
     const id = Semibook.rawIdToId(event.args.id);
     if (id === undefined)
       throw new Error("Received OfferFail event with id = 0");
-    removedOffer = this.#cacheOperations.removeOffer(state, id);
+    removedOffer = this.#cacheOperations.removeOfferDueToEvent(state, id);
     Array.from(this.#eventListeners.keys()).forEach(
       (listener) =>
         void listener({
@@ -1016,7 +1010,7 @@ class Semibook
     const id = Semibook.rawIdToId(event.args.id);
     if (id === undefined)
       throw new Error("Received OfferSuccess event with id = 0");
-    removedOffer = this.#cacheOperations.removeOffer(state, id);
+    removedOffer = this.#cacheOperations.removeOfferDueToEvent(state, id);
     Array.from(this.#eventListeners.keys()).forEach(
       (listener) =>
         void listener({
@@ -1054,10 +1048,10 @@ class Semibook
         block,
         fromId,
         options.chunkSize,
-        (chunk) =>
-          chunk.length === 0
+        (tick, bin) =>
+          bin.length === 0
             ? true
-            : this.isPriceBetter(desiredPrice, chunk[chunk.length - 1].tick),
+            : this.isPriceBetter(desiredPrice, bin[bin.length - 1].tick),
       );
     } else if ("desiredVolume" in options) {
       const desiredVolume = options.desiredVolume;
@@ -1065,11 +1059,10 @@ class Semibook
         if (desiredVolume.to === "buy") {
           return offer.gives;
         } else {
-          const offerWants = this.tickPriceHelper.inboundFromOutbound(
+          return this.tickPriceHelper.inboundFromOutbound(
             offer.tick,
             offer.gives,
           );
-          return offerWants;
         }
       };
       let volume = Big(0);
@@ -1077,21 +1070,20 @@ class Semibook
         block,
         fromId,
         options.chunkSize,
-        (chunk) => {
-          chunk.forEach((offer) => {
+        (tick, bin) => {
+          bin.forEach((offer) => {
             volume = volume.plus(getOfferVolume(offer));
           });
           return volume.gte(desiredVolume.given);
         },
       );
     } else {
-      const maxOffers = options.maxOffers;
+      const targetNumberOfTicks = options.targetNumberOfTicks;
       return await this.#fetchOfferListPrefixUntil(
         block,
         fromId,
         options.chunkSize,
-        (chunk, allFetched) =>
-          allFetched.length >= (maxOffers ?? Semibook.DEFAULT_MAX_OFFERS),
+        (tick, bin, allFetched) => allFetched.size >= targetNumberOfTicks,
       );
     }
   }
@@ -1101,17 +1093,21 @@ class Semibook
     block: BlockManager.BlockWithoutParentHash,
     fromId: number | undefined,
     chunkSize: number | undefined,
-    processChunk: (
-      chunk: Market.Offer[],
-      allFetched: Market.Offer[],
+    processBin: (
+      tick: number,
+      bin: Market.Offer[],
+      allFetched: Map<number, Market.Offer[]>, // tick -> offers
     ) => boolean, // Should return `true` when fetching should stop
+    ignoreFirstOffer = false, // Should be `true` when `fromId` is the last offer in the cache
   ): Promise<Semibook.FetchOfferListResult> {
     const { outbound_tkn, inbound_tkn } = this.market.getOutboundInbound(
       this.ba,
     );
 
-    let chunk: Market.Offer[];
-    const result: Market.Offer[] = [];
+    let currentTick: number | undefined = undefined;
+    let bin: Market.Offer[] = [];
+    const bins: Map<number, Market.Offer[]> = new Map();
+    let shouldStop = false;
     do {
       try {
         const res: [
@@ -1126,14 +1122,14 @@ class Semibook
             tickSpacing: this.market.tickSpacing,
           },
           Semibook.idToRawId(fromId),
-          chunkSize ?? Semibook.DEFAULT_MAX_OFFERS,
+          chunkSize ?? Semibook.DEFAULT_CHUNK_SIZE,
           { blockTag: block.number },
         );
-        const [_nextId, offerIds, offers, details] = res;
+        const [rawNextId, rawOfferIds, rawOffers, rawOfferDetails] = res;
 
-        chunk = offerIds.map((offerId, index) => {
-          const offer = offers[index];
-          const detail = details[index];
+        const offers = rawOfferIds.map((offerId, index) => {
+          const offer = rawOffers[index];
+          const detail = rawOfferDetails[index];
           return {
             offer_gasbase: detail.kilo_offer_gasbase.toNumber() * 1000,
             next: Semibook.rawIdToId(offer.next),
@@ -1146,17 +1142,51 @@ class Semibook
           };
         });
 
-        result.push(...chunk);
+        if (ignoreFirstOffer) {
+          offers.shift();
+          ignoreFirstOffer = false;
+        }
 
-        fromId = Semibook.rawIdToId(_nextId);
+        for (const offer of offers) {
+          // If offer does not belong in the current bin, process the current bin first
+          if (currentTick !== undefined && offer.tick !== currentTick) {
+            bins.set(currentTick, bin);
+            shouldStop ||= processBin(currentTick, bin, bins);
+            currentTick = offer.tick;
+            bin = [];
+          }
+
+          if (currentTick === undefined) {
+            currentTick = offer.tick;
+            bin = [];
+          }
+
+          bin.push(offer);
+        }
+
+        // Was the last processed offer the last offer in a bin?
+        if (offers.length > 0) {
+          const lastOffer = offers[offers.length - 1];
+          if (lastOffer.next === undefined) {
+            bins.set(lastOffer.tick, bin);
+            shouldStop ||= processBin(lastOffer.tick, bin, bins);
+            currentTick = undefined;
+            bin = [];
+          }
+        }
+
+        fromId = Semibook.rawIdToId(rawNextId);
       } catch (e) {
         return { error: "FailedInitialize", ok: undefined };
       }
-    } while (!processChunk(chunk, result) && fromId !== undefined);
+    } while (!shouldStop && fromId !== undefined);
 
     return {
       error: undefined,
-      ok: result,
+      ok: {
+        bins,
+        endOfListReached: fromId === undefined,
+      },
     };
   }
 
@@ -1226,30 +1256,23 @@ class Semibook
     const result = Object.assign({}, options);
 
     if (
-      !("maxOffers" in options) &&
+      !("targetNumberOfTicks" in options) &&
       !("desiredVolume" in options) &&
       !("desiredPrice" in options)
     ) {
-      (result as any)["maxOffers"] = Semibook.DEFAULT_MAX_OFFERS;
+      (result as any)["targetNumberOfTicks"] =
+        Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS;
     }
 
     if (
-      "maxOffers" in options &&
-      options.maxOffers !== undefined &&
-      options.maxOffers < 0
+      "targetNumberOfTicks" in options &&
+      options.targetNumberOfTicks !== undefined &&
+      options.targetNumberOfTicks < 0
     ) {
-      throw Error("Semibook options.maxOffers must be >= 0");
+      throw Error("Semibook options.targetNumberOfTicks must be >= 0");
     }
 
-    let chunkSize = options.chunkSize;
-    if (chunkSize === undefined) {
-      chunkSize =
-        "maxOffers" in options &&
-        options.maxOffers !== undefined &&
-        options.maxOffers > 0
-          ? options.maxOffers
-          : Semibook.DEFAULT_MAX_OFFERS;
-    }
+    const chunkSize = options.chunkSize ?? Semibook.DEFAULT_CHUNK_SIZE;
     if (chunkSize <= 0) {
       throw Error("Semibook options.chunkSize must be > 0");
     }
@@ -1359,72 +1382,117 @@ class CacheIterator implements Semibook.CacheIterator {
   }
 }
 
+// Implements the logic of cache modifications.
+// Only used internally, exposed for testing.
+// All modifications of the cache must be called in a context where #cacheLock is acquired.
 export class SemibookCacheOperations {
-  // Assumes id is not already in the cache
-  // Returns `true` if the offer was inserted into the cache; Otherwise, `false`.
-  // This modifies the cache so must be called in a context where #cacheLock is acquired
-  insertOffer(
-    state: Semibook.State,
-    offer: Market.Offer,
-    options?: { maxOffers?: number },
-  ): boolean {
-    state.offerCache.set(offer.id, offer);
-    const bin = this.getOrCreateBinFromCache(state, offer);
-
-    if (bin.firstOfferId === undefined) {
-      bin.firstOfferId = offer.id;
-    }
-
-    if (bin.lastOfferId !== offer.id) {
-      offer.prev = bin.lastOfferId;
-      // Previous offer may not be in the cache
-      const prevOffer = state.offerCache.get(offer.prev);
-      if (prevOffer !== undefined) {
-        prevOffer.next = offer.id;
-      }
-    }
-    bin.lastOfferId = offer.id;
-
-    // If maxOffers option has been specified, evict worst offer if over max size
-    if (
-      options &&
-      "maxOffers" in options &&
-      options.maxOffers !== undefined &&
-      state.offerCache.size > options.maxOffers
-    ) {
-      // state.offerCache.size > this.options.maxOffers  implies  worstBinInCache !== undefined
-      const worstBinInCache = state.worstBinInCache!;
-      const removedOffer = this.removeOffer(
-        state,
-        worstBinInCache.lastOfferId,
-        true,
+  // Marks an incomplete cache as known to be complete.
+  markComplete(state: Semibook.State): void {
+    if (state.isComplete) {
+      throw Error(
+        "cache is already complete, so should never be marked complete again",
       );
-
-      if (offer.id === removedOffer?.id) {
-        return false;
-      }
     }
+    state.isComplete = true;
+  }
+
+  // Inserts a complete bin into an incomplete cache.
+  // The inserted bin must be the next non-empty bin in the offer list after the bins already in the cache.
+  insertCompleteBin(state: Semibook.State, offers: Market.Offer[]): void {
+    if (state.isComplete) {
+      throw Error(
+        "cache is already complete, so should never insert more bins",
+      );
+    }
+
+    const tick = offers[0].tick;
+    if (
+      state.worstBinInCache !== undefined &&
+      tick <= state.worstBinInCache.tick
+    ) {
+      throw Error(
+        "tick must be greater than the tick of the worst bin in the cache",
+      );
+    }
+
+    const bin: Semibook.Bin = {
+      tick,
+      offerCount: offers.length,
+      firstOfferId: offers[0].id,
+      lastOfferId: offers[offers.length - 1].id,
+      prev: state.worstBinInCache,
+      next: undefined,
+    };
+    state.binCache.set(tick, bin);
+
+    // Insert the bin at the end of the bin list (which may be empty)
+    if (state.worstBinInCache !== undefined) {
+      state.worstBinInCache.next = bin;
+    } else {
+      state.bestBinInCache = bin;
+    }
+    state.worstBinInCache = bin;
+
+    // offer.prev and offer.next are already set when they were fetched from chain
+    for (const offer of offers) {
+      state.offerCache.set(offer.id, offer);
+    }
+  }
+
+  // Insert an offer from an OfferWrite event into the cache if it is an extension of the cache prefix:
+  // - If the cache is complete, all new offers are extensions of the cache prefix
+  // - If the cache is incomplete, only offers with a tick less than or equal to the worst tick in the cache are extensions of the cache prefix.
+  // Returns `true` if the offer was inserted into the cache; Otherwise, `false`.
+  insertOfferDueToEvent(state: Semibook.State, offer: Market.Offer): boolean {
+    if (
+      !state.isComplete &&
+      (state.worstBinInCache === undefined ||
+        offer.tick > state.worstBinInCache.tick)
+    ) {
+      return false;
+    }
+
+    state.offerCache.set(offer.id, offer);
+    let bin = state.binCache.get(offer.tick);
+    if (bin !== undefined) {
+      // Insert offer at the end of the existing bin
+      state.offerCache.get(bin.lastOfferId)!.next = offer.id;
+      offer.prev = bin.lastOfferId;
+      bin.lastOfferId = offer.id;
+      bin.offerCount++;
+    } else {
+      bin = this.#createBinWithOffer(state, offer);
+    }
+
     return true;
   }
 
-  // remove offer id from book and connect its prev/next.
-  // return 'undefined' if offer was not found in book
-  // This modifies the cache so must be called in a context where #cacheLock is acquired
-  removeOffer(
+  // Remove an offer from the cache due to an event (update, success, retract, fail).
+  // For a complete cache, removed offers may only be unknown if:
+  // - the event is an OfferWrite that is not an update, i.e. the offer is new and does not need to be removed before being reinserted
+  // - the event is an OfferRetract since OfferRetract may also be emitted when deprovisioning non-live offers
+  // Returns the removed offer if it was in the cache; Otherwise, `undefined` is returned.
+  removeOfferDueToEvent(
     state: Semibook.State,
     id: number,
-    removeOfferBecauseCacheIsFull: boolean = false,
+    allowUnknownId = false,
   ): Market.Offer | undefined {
     const offer = state.offerCache.get(id);
-    if (offer === undefined) return undefined;
+    if (offer === undefined) {
+      if (state.isComplete && !allowUnknownId) {
+        throw Error(
+          "offer to be removed must be in cache if cache is complete, unless allowUnknownId is true",
+        );
+      }
+      return undefined;
+    }
     state.offerCache.delete(id);
 
-    const tick = offer.tick;
-    const bin = this.getBinFromCacheOrFail(state, tick);
+    const bin = state.binCache.get(offer.tick)!;
 
     // Will the bin become empty? If so, remove it from the cache.
     if (bin.firstOfferId === offer.id && bin.lastOfferId === offer.id) {
-      state.binCache.delete(tick);
+      state.binCache.delete(offer.tick);
 
       if (bin.prev !== undefined) {
         bin.prev.next = bin.next;
@@ -1439,58 +1507,39 @@ export class SemibookCacheOperations {
       }
     } else {
       // Remove the offer from the bin
-      if (bin.firstOfferId === offer.id) {
-        bin.firstOfferId = offer.next!; // since the bin has multiple offers  =>  offer.next !== undefined
-      }
-      if (bin.lastOfferId === offer.id) {
-        bin.lastOfferId = offer.prev!; // since the bin has multiple offers  =>  offer.prev !== undefined
-      }
-
       const prevOffer = state.offerCache.get(offer.prev!);
-      // if the offer is removed because cache is full we keep next unchanged even if we do not have it in our cache
-      if (prevOffer !== undefined && !removeOfferBecauseCacheIsFull) {
+      const nextOffer = state.offerCache.get(offer.next!);
+      if (prevOffer === undefined) {
+        bin.firstOfferId = nextOffer!.id; // since the bin has multiple offers && prevOffer == undefined  =>  nextOffer !== undefined
+      } else {
         prevOffer.next = offer.next;
       }
-
-      const nextOffer = state.offerCache.get(offer.next!);
-      if (nextOffer !== undefined) {
+      if (nextOffer === undefined) {
+        bin.lastOfferId = prevOffer!.id; // since the bin has multiple offers && nextOffer == undefined  =>  prevOffer !== undefined
+      } else {
         nextOffer.prev = offer.prev;
       }
+      bin.offerCount--;
     }
 
     return offer;
   }
 
-  getOfferFromCacheOrFail(state: Semibook.State, id: number): Market.Offer {
-    const offer = state.offerCache.get(id);
-    if (offer === undefined) throw Error(`Offer ${id} is not in cache`);
-    return offer;
-  }
-
-  getBinFromCacheOrFail(state: Semibook.State, tick: number): Semibook.Bin {
-    const bin = state.binCache.get(tick);
-    if (bin === undefined) throw Error(`Bin ${tick} is not in cache`);
-    return bin;
-  }
-
-  getOrCreateBinFromCache(
+  #createBinWithOffer(
     state: Semibook.State,
     offer: Market.Offer,
   ): Semibook.Bin {
-    const tick = offer.tick;
-    let bin = state.binCache.get(tick);
-    if (bin !== undefined) return bin;
+    const { prevBin, nextBin } = this.#findPrevAndNextBins(state, offer.tick);
 
-    const { prevBin, nextBin } = this.findPrevAndNextBins(state, tick);
-
-    bin = {
-      tick,
+    const bin = {
+      tick: offer.tick,
+      offerCount: 1,
       firstOfferId: offer.id,
       lastOfferId: offer.id,
       prev: prevBin,
       next: nextBin,
     };
-    state.binCache.set(tick, bin);
+    state.binCache.set(offer.tick, bin);
 
     if (prevBin === undefined) {
       state.bestBinInCache = bin;
@@ -1507,7 +1556,7 @@ export class SemibookCacheOperations {
     return bin;
   }
 
-  findPrevAndNextBins(
+  #findPrevAndNextBins(
     state: Semibook.State,
     tick: number,
   ): { prevBin: Semibook.Bin | undefined; nextBin: Semibook.Bin | undefined } {

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -1447,7 +1447,7 @@ describe("Market integration tests suite", () => {
     }[];
     /* Start testing */
 
-    const book = await market.requestBook({ maxOffers: 6 });
+    const book = await market.requestBook({ targetNumberOfTicks: 6 });
 
     // Convert big.js numbers to string for easier debugging
     const stringify = ({ bids, asks }: { bids: Bs; asks: Bs }) => {

--- a/test/integration/offermaker.integration.test.ts
+++ b/test/integration/offermaker.integration.test.ts
@@ -51,7 +51,7 @@ describe("OfferMaker integration test suite", () => {
       base: "TokenA",
       quote: "TokenB",
       tickSpacing: 1,
-      bookOptions: { maxOffers: 30 },
+      bookOptions: { targetNumberOfTicks: 30 },
     });
     onchain_lp = await LiquidityProvider.connect(logic, 20000, market);
     eoa_lp = await mgv.liquidityProvider(market);

--- a/test/integration/restingOrder.integration.test.ts
+++ b/test/integration/restingOrder.integration.test.ts
@@ -54,7 +54,7 @@ describe("RestingOrder", () => {
         base: "TokenA",
         quote: "TokenB",
         tickSpacing: 1,
-        bookOptions: { maxOffers: 30 },
+        bookOptions: { targetNumberOfTicks: 30 },
       });
 
       //check that contract responds
@@ -86,7 +86,7 @@ describe("RestingOrder", () => {
         base: "TokenA",
         quote: "TokenB",
         tickSpacing: 1,
-        bookOptions: { maxOffers: 30 },
+        bookOptions: { targetNumberOfTicks: 30 },
       });
 
       const gasreq = configuration.mangroveOrder.getRestingOrderGasreq(

--- a/test/unit/semibook.unit.test.ts
+++ b/test/unit/semibook.unit.test.ts
@@ -6,6 +6,7 @@ import { BigNumber } from "ethers";
 import { anything, deepEqual, instance, mock, when } from "ts-mockito";
 import UnitCalculations from "../../src/util/unitCalculations";
 import MangroveEventSubscriber from "../../src/mangroveEventSubscriber";
+import { expect } from "chai";
 import { TokenCalculations } from "../../src/token";
 describe("Semibook unit test suite", () => {
   describe("getIsVolumeDesiredForAsks", () => {
@@ -147,923 +148,6 @@ describe("Semibook unit test suite", () => {
       const result = Semibook.getIsVolumeDesiredForBids(opts);
       // Assert
       assert.equal(result, true);
-    });
-  });
-
-  describe("insertOffer", () => {
-    it("inserts offer in empty book", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      const offer: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(1),
-        price: Big(1),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      //Act
-      book.insertOffer(state, offer);
-      // Assert
-      assert.equal(state.offerCache.size, 1);
-      assert.equal(state.binCache.size, 1);
-      assert.notEqual(state.bestBinInCache, undefined);
-      assert.notEqual(state.worstBinInCache, undefined);
-      assert.equal(state.bestBinInCache?.tick, offer.tick);
-      assert.deepStrictEqual(state.bestBinInCache, state.worstBinInCache);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer.id);
-      assert.deepStrictEqual(state.bestBinInCache?.lastOfferId, offer.id);
-      assert.deepStrictEqual(offer.next, undefined);
-      assert.deepStrictEqual(offer.prev, undefined);
-    });
-
-    it("inserts offer in non empty book, offer is worse", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        price: Big(1),
-        wants: Big(1),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        id: 2,
-        maker: "0x2",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(2),
-        wants: Big(2),
-        price: Big(1),
-        next: undefined,
-        prev: undefined,
-        tick: 1,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-
-      //Act
-      book.insertOffer(state, offer2);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 2);
-      assert.notDeepStrictEqual(state.bestBinInCache, state.worstBinInCache);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: undefined,
-        next: state.worstBinInCache,
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: state.bestBinInCache,
-        next: undefined,
-      });
-    });
-
-    it("inserts offer in non empty book, offer is better", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(1),
-        price: Big(1),
-        next: undefined,
-        prev: undefined,
-        tick: 1,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2 = { ...offer1, id: 2, tick: 0 };
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-
-      //Act
-      book.insertOffer(state, offer2);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 2);
-      assert.notDeepStrictEqual(state.bestBinInCache, state.worstBinInCache);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer2.id);
-      assert.deepStrictEqual(state.worstBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: state.bestBinInCache,
-        next: undefined,
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: undefined,
-        next: state.worstBinInCache,
-      });
-    });
-
-    it("inserts offer in non empty book, offer is in the middle", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 2,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer3);
-
-      //Act
-      book.insertOffer(state, offer2);
-
-      // Assert
-      assert.equal(state.offerCache.size, 3);
-      assert.equal(state.binCache.size, 3);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer3.next, undefined);
-      assert.deepStrictEqual(offer3.prev, undefined);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: undefined,
-        next: state.binCache.get(offer2.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: state.binCache.get(offer1.tick),
-        next: state.binCache.get(offer3.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer3.tick), {
-        tick: offer3.tick,
-        firstOfferId: offer3.id,
-        lastOfferId: offer3.id,
-        prev: state.binCache.get(offer2.tick),
-        next: undefined,
-      });
-    });
-
-    it("inserts offer in non empty book, offer is in the middle at an already existing tick", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 2,
-      };
-      const offer4: Market.Offer = {
-        ...offer1,
-        id: 4,
-        tick: 1,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-      book.insertOffer(state, offer3);
-
-      //Act
-      book.insertOffer(state, offer4);
-
-      // Assert
-      assert.equal(state.offerCache.size, 4);
-      assert.equal(state.binCache.size, 3);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, offer4.id);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer3.next, undefined);
-      assert.deepStrictEqual(offer3.prev, undefined);
-      assert.deepStrictEqual(offer4.next, undefined);
-      assert.deepStrictEqual(offer4.prev, offer2.id);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: undefined,
-        next: state.binCache.get(offer2.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer4.id,
-        prev: state.binCache.get(offer1.tick),
-        next: state.binCache.get(offer3.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer3.tick), {
-        tick: offer3.tick,
-        firstOfferId: offer3.id,
-        lastOfferId: offer3.id,
-        prev: state.binCache.get(offer2.tick),
-        next: undefined,
-      });
-    });
-
-    it("inserts offer in non empty book, offer is at worse tick, tick already exist", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 1,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-
-      //Act
-      book.insertOffer(state, offer3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 3);
-      assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, offer3.id);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer3.next, undefined);
-      assert.deepStrictEqual(offer3.prev, offer2.id);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: undefined,
-        next: state.binCache.get(offer2.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer3.id,
-        prev: state.binCache.get(offer1.tick),
-        next: undefined,
-      });
-    });
-
-    it("inserts offer in non empty book, offer is at a better tick, tick already exist", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 0,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-
-      //Act
-      book.insertOffer(state, offer3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 3);
-      assert.equal(state.binCache.size, 2);
-
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
-      assert.deepStrictEqual(offer1.next, offer3.id);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer3.next, undefined);
-      assert.deepStrictEqual(offer3.prev, offer1.id);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer3.id,
-        prev: undefined,
-        next: state.binCache.get(offer2.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: state.binCache.get(offer1.tick),
-        next: undefined,
-      });
-    });
-
-    it("inserting offer exceeds maxOffer size, offer is not worst offer", () => {
-      ///Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      const options = { maxOffers: 5 };
-      for (let i = 0; i < options.maxOffers; i++) {
-        const offer: Market.Offer = { ...offer1, id: i };
-        book.insertOffer(state, offer, options);
-      }
-
-      //Act
-      const offer: Market.Offer = {
-        ...offer1,
-        id: 6,
-        tick: -1,
-      };
-
-      const isInserted = book.insertOffer(state, offer, options);
-
-      // Assert
-      assert.equal(state.offerCache.size, 5);
-      assert.equal(isInserted, true);
-    });
-
-    it("inserting offer exceeds maxOffer size, offer is worst offer", () => {
-      ///Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      const options = { maxOffers: 5 };
-      for (let i = 0; i < options.maxOffers; i++) {
-        const offer: Market.Offer = { ...offer1, id: i };
-        book.insertOffer(state, offer, options);
-      }
-
-      //Act
-      const offer: Market.Offer = {
-        ...offer1,
-        id: 6,
-        price: Big(0),
-        tick: 0,
-      };
-
-      const isInserted = book.insertOffer(state, offer, options);
-
-      // Assert
-      assert.equal(state.offerCache.size, 5);
-      assert.equal(isInserted, false);
-    });
-  });
-
-  describe("removeOffer", () => {
-    it("removes offer from empty book", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      //Act
-      const offerRemoved = book.removeOffer(state, 1);
-
-      // Assert
-      assert.equal(state.offerCache.size, 0);
-      assert.equal(state.binCache.size, 0);
-      assert.equal(offerRemoved, undefined);
-    });
-
-    it("removes offer from non empty book, offer is best offer, has others at same tick", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 1,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-      book.insertOffer(state, offer3);
-
-      //Act
-      const offerRemoved = book.removeOffer(state, 3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offerRemoved, offer3);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: undefined,
-        next: state.binCache.get(offer2.tick),
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: state.binCache.get(offer1.tick),
-        next: undefined,
-      });
-    });
-
-    it("removes offer from non empty book, offer is best offer, does not have others at same tick", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(1),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 0,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 0,
-      };
-
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 1,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-      book.insertOffer(state, offer3);
-
-      //Act
-      const offerRemoved = book.removeOffer(state, 3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 1);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
-      assert.deepStrictEqual(offer1.next, offer2.id);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offer2.prev, offer1.id);
-      assert.deepStrictEqual(offerRemoved, offer3);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer2.id,
-        prev: undefined,
-        next: undefined,
-      });
-      assert.deepStrictEqual(state.binCache.get(offer3.tick), undefined);
-    });
-
-    it("removes offer from non empty book, offer is worst offer, has others at same tick", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(2),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 1,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 0,
-      };
-
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 0,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-      book.insertOffer(state, offer3);
-
-      //Act
-      const offerRemoved = book.removeOffer(state, 3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer2.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer1.id);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer1.next, undefined);
-      assert.deepStrictEqual(offer2.prev, undefined);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offerRemoved, offer3);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer1.id,
-        prev: state.binCache.get(offer2.tick),
-        next: undefined,
-      });
-      assert.deepStrictEqual(state.binCache.get(offer2.tick), {
-        tick: offer2.tick,
-        firstOfferId: offer2.id,
-        lastOfferId: offer2.id,
-        prev: undefined,
-        next: state.binCache.get(offer1.tick),
-      });
-    });
-
-    it("removes offer from non empty book, offer is worst offer, has others at same tick", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer1: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 1,
-        gasreq: 1,
-        gives: Big(2),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 1,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const offer2: Market.Offer = {
-        ...offer1,
-        id: 2,
-        tick: 1,
-      };
-
-      const offer3: Market.Offer = {
-        ...offer1,
-        id: 3,
-        tick: 0,
-      };
-
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer1);
-      book.insertOffer(state, offer2);
-      book.insertOffer(state, offer3);
-
-      //Act
-      const offerRemoved = book.removeOffer(state, 3);
-
-      // Assert
-      assert.equal(state.offerCache.size, 2);
-      assert.equal(state.binCache.size, 1);
-      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
-      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
-      assert.deepStrictEqual(offer1.prev, undefined);
-      assert.deepStrictEqual(offer1.next, offer2.id);
-      assert.deepStrictEqual(offer2.prev, offer1.id);
-      assert.deepStrictEqual(offer2.next, undefined);
-      assert.deepStrictEqual(offerRemoved, offer3);
-      assert.deepStrictEqual(state.binCache.get(offer1.tick), {
-        tick: offer1.tick,
-        firstOfferId: offer1.id,
-        lastOfferId: offer2.id,
-        prev: undefined,
-        next: undefined,
-      });
-      assert.deepStrictEqual(state.binCache.get(offer3.tick), undefined);
-    });
-
-    it("removes last offer in book", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 2,
-        gasreq: 1,
-        gives: Big(2),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 2,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      book.insertOffer(state, offer);
-
-      //Act
-      const offerRemoved = book.removeOffer(state, 1);
-
-      // Assert
-      assert.equal(state.offerCache.size, 0);
-      assert.equal(state.binCache.size, 0);
-      assert.deepStrictEqual(state.bestBinInCache, undefined);
-      assert.deepStrictEqual(state.worstBinInCache, undefined);
-      assert.deepStrictEqual(offerRemoved, offer);
-    });
-  });
-
-  describe("getOfferFromCacheOrFail", () => {
-    it("throws error when offer is not in cache", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-      //Act
-
-      // Assert
-      assert.throws(
-        () => book.getOfferFromCacheOrFail(state, 1),
-        new Error(`Offer 1 is not in cache`),
-      );
-    });
-
-    it("returns offer when offer is in cache", () => {
-      //Arrange
-      const book = new SemibookCacheOperations();
-      const offer: Market.Offer = {
-        id: 1,
-        maker: "0x1",
-        gasprice: 2,
-        gasreq: 1,
-        gives: Big(2),
-        wants: Big(0),
-        price: Big(0),
-        next: undefined,
-        prev: undefined,
-        tick: 2,
-        offer_gasbase: 1000,
-        volume: Big(42),
-      };
-      const state: Semibook.State = {
-        offerCache: new Map(),
-        binCache: new Map(),
-        bestBinInCache: undefined,
-        worstBinInCache: undefined,
-      };
-
-      book.insertOffer(state, offer);
-
-      //Act
-      const result = book.getOfferFromCacheOrFail(state, 1);
-
-      // Assert
-      assert.deepStrictEqual(result, offer);
     });
   });
 
@@ -1266,5 +350,1171 @@ describe("Semibook unit test suite", () => {
 
       assert.deepEqual(result, expectedOffer);
     });
+  });
+
+  describe(SemibookCacheOperations.name, () => {
+    const cacheOperations = new SemibookCacheOperations();
+
+    function createEmptyState(): Semibook.State {
+      return {
+        offerCache: new Map(),
+        binCache: new Map(),
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
+        isComplete: false,
+      };
+    }
+
+    function makeOffer({
+      id,
+      tick,
+    }: {
+      id: number;
+      tick: number;
+    }): Market.Offer {
+      return {
+        id,
+        tick,
+        maker: `0x${id}`,
+        gasprice: id,
+        gasreq: id,
+        gives: Big(id),
+        price: Big(id),
+        wants: Big(id),
+        next: undefined,
+        prev: undefined,
+        offer_gasbase: id,
+        volume: Big(id),
+      };
+    }
+
+    function makeBinOffers({
+      tick,
+      count,
+      fromId,
+    }: {
+      tick: number;
+      count: number;
+      fromId: number;
+    }): Market.Offer[] {
+      const result: Market.Offer[] = [];
+      let prev: Market.Offer | undefined = undefined;
+      for (let id = fromId; id < fromId + count; ++id) {
+        const offer = makeOffer({ id, tick });
+        offer.prev = prev?.id;
+        if (prev !== undefined) {
+          prev.next = offer.id;
+        }
+        prev = offer;
+        result.push(offer);
+      }
+      return result;
+    }
+
+    describe(SemibookCacheOperations.prototype.markComplete.name, () => {
+      it("marks incomplete cache as complete", () => {
+        // Arrange
+        const state = createEmptyState();
+
+        // Act
+        cacheOperations.markComplete(state);
+
+        // Assert
+        expect(state.isComplete).to.equal(true);
+      });
+
+      it("cannot mark already complete cache as complete", () => {
+        // Arrange
+        const state = createEmptyState();
+        cacheOperations.markComplete(state);
+
+        // Act & Assert
+        expect(() => cacheOperations.markComplete(state)).to.throw();
+      });
+    });
+
+    describe(SemibookCacheOperations.prototype.insertCompleteBin.name, () => {
+      it("cannot insert bin into complete cache", () => {
+        // Arrange
+        const state = createEmptyState();
+        cacheOperations.markComplete(state);
+        const tick = 0;
+        const offers = makeBinOffers({ tick, count: 1, fromId: 1 });
+
+        // Act & Assert
+        expect(() =>
+          cacheOperations.insertCompleteBin(state, offers),
+        ).to.throw();
+      });
+
+      describe("incomplete empty cache", () => {
+        let state: Semibook.State;
+        beforeEach(() => {
+          state = createEmptyState();
+        });
+
+        it("inserts singleton bin", () => {
+          // Arrange
+          const tick = 0;
+          const offers = makeBinOffers({ tick, count: 1, fromId: 1 });
+
+          // Act
+          cacheOperations.insertCompleteBin(state, offers);
+
+          // Assert
+          expect(state.isComplete).to.equal(false);
+
+          expect([...state.offerCache.entries()]).to.deep.equal(
+            offers.map((o) => [o.id, o]),
+          );
+
+          expect(state.binCache.size).to.equal(1);
+          expect(state.binCache.get(tick)).to.deep.equal({
+            tick: tick,
+            offerCount: offers.length,
+            firstOfferId: offers[0].id,
+            lastOfferId: offers[offers.length - 1].id,
+            prev: undefined,
+            next: undefined,
+          });
+
+          expect(state.bestBinInCache).to.be.equal(state.binCache.get(tick));
+          expect(state.worstBinInCache).to.be.equal(state.binCache.get(tick));
+        });
+
+        it("inserts bin with multiple (3) offers", () => {
+          // Arrange
+          const tick = 0;
+          const offers = makeBinOffers({ tick, count: 3, fromId: 1 });
+
+          // Act
+          cacheOperations.insertCompleteBin(state, offers);
+
+          // Assert
+          expect(state.isComplete).to.equal(false);
+
+          expect([...state.offerCache.entries()]).to.deep.equal(
+            offers.map((o) => [o.id, o]),
+          );
+
+          expect(state.binCache.size).to.equal(1);
+          expect(state.binCache.get(tick)).to.deep.equal({
+            tick: tick,
+            offerCount: offers.length,
+            firstOfferId: offers[0].id,
+            lastOfferId: offers[offers.length - 1].id,
+            prev: undefined,
+            next: undefined,
+          });
+
+          expect(state.bestBinInCache).to.be.equal(state.binCache.get(tick));
+          expect(state.worstBinInCache).to.be.equal(state.binCache.get(tick));
+        });
+      });
+
+      describe("incomplete cache with one bin", () => {
+        let state: Semibook.State;
+        let existingBin: Semibook.Bin;
+        let existingOffers: Market.Offer[];
+        beforeEach(() => {
+          state = createEmptyState();
+
+          const tick = 0;
+          existingOffers = makeBinOffers({ tick, count: 1, fromId: 1 });
+          cacheOperations.insertCompleteBin(state, existingOffers);
+          existingBin = state.binCache.get(tick)!;
+        });
+
+        it("cannot insert bin with lower tick (cache invariant violation)", () => {
+          // Arrange
+          const tick = existingBin.tick - 1;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: existingBin.lastOfferId + 1,
+          });
+
+          // Act & Assert
+          expect(() =>
+            cacheOperations.insertCompleteBin(state, offers),
+          ).to.throw();
+        });
+
+        it("cannot insert bin with same tick (cache invariant violation)", () => {
+          // Arrange
+          const tick = existingBin.tick;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: existingBin.lastOfferId + 1,
+          });
+
+          // Act & Assert
+          expect(() =>
+            cacheOperations.insertCompleteBin(state, offers),
+          ).to.throw();
+        });
+
+        it("insert bin with higher tick", () => {
+          // Arrange
+          const tick = existingBin.tick + 1;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: existingBin.lastOfferId + 1,
+          });
+
+          // Act
+          cacheOperations.insertCompleteBin(state, offers);
+
+          // Assert
+          expect(state.isComplete).to.equal(false);
+
+          expect([...state.offerCache.entries()]).to.deep.equal(
+            [...existingOffers, ...offers].map((o) => [o.id, o]),
+          );
+
+          expect(state.binCache.size).to.equal(2);
+          expect(state.binCache.get(tick)).to.deep.equal({
+            tick: tick,
+            offerCount: offers.length,
+            firstOfferId: offers[0].id,
+            lastOfferId: offers[offers.length - 1].id,
+            prev: existingBin,
+            next: undefined,
+          });
+          expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+            ...existingBin,
+            prev: undefined,
+            next: state.binCache.get(tick),
+          });
+
+          expect(state.bestBinInCache).to.be.equal(existingBin);
+          expect(state.worstBinInCache).to.be.equal(state.binCache.get(tick));
+        });
+      });
+
+      describe("incomplete cache with multiple (3) bins", () => {
+        let state: Semibook.State;
+        let existingBins: Semibook.Bin[];
+        let existingOffersList: Market.Offer[][];
+        beforeEach(() => {
+          state = createEmptyState();
+
+          existingBins = [];
+          existingOffersList = [];
+          for (let i = 0; i < 3; ++i) {
+            const tick = i * 2;
+            existingOffersList[i] = makeBinOffers({
+              tick,
+              count: 1,
+              fromId: i + 1,
+            });
+            cacheOperations.insertCompleteBin(state, existingOffersList[i]);
+            existingBins[i] = state.binCache.get(tick)!;
+          }
+        });
+
+        it("cannot insert bin with lower tick (cache invariant violation)", () => {
+          // Arrange
+          const tick = existingBins[0].tick - 1;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: state.worstBinInCache!.lastOfferId + 1,
+          });
+
+          // Act & Assert
+          expect(() =>
+            cacheOperations.insertCompleteBin(state, offers),
+          ).to.throw();
+        });
+
+        it("cannot insert bin with inbetween tick (cache invariant violation)", () => {
+          // Arrange
+          const tick = existingBins[0].tick + 1;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: state.worstBinInCache!.lastOfferId + 1,
+          });
+
+          // Act & Assert
+          expect(() =>
+            cacheOperations.insertCompleteBin(state, offers),
+          ).to.throw();
+        });
+
+        it("cannot insert bin with existing tick (cache invariant violation)", () => {
+          // Arrange
+          const tick = existingBins[1].tick;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: state.worstBinInCache!.lastOfferId + 1,
+          });
+
+          // Act & Assert
+          expect(() =>
+            cacheOperations.insertCompleteBin(state, offers),
+          ).to.throw();
+        });
+
+        it("insert bin with higher tick", () => {
+          // Arrange
+          const tick = existingBins[existingBins.length - 1].tick + 1;
+          const offers = makeBinOffers({
+            tick,
+            count: 1,
+            fromId: state.worstBinInCache!.lastOfferId + 1,
+          });
+
+          // Act
+          cacheOperations.insertCompleteBin(state, offers);
+
+          // Assert
+          expect(state.isComplete).to.equal(false);
+
+          expect(state.offerCache.size).to.equal(
+            existingOffersList.reduce((prev, curr) => curr.length + prev, 0) +
+              offers.length,
+          );
+          expect([...state.offerCache.entries()]).to.deep.equal(
+            [...existingOffersList.flat(), ...offers].map((o) => [o.id, o]),
+          );
+
+          expect(state.binCache.size).to.equal(existingBins.length + 1);
+          expect(state.binCache.get(tick)).to.deep.equal({
+            tick: tick,
+            offerCount: offers.length,
+            firstOfferId: offers[0].id,
+            lastOfferId: offers[offers.length - 1].id,
+            prev: existingBins[existingBins.length - 1],
+            next: undefined,
+          });
+          for (let i = 0; i < existingBins.length; ++i) {
+            expect(state.binCache.get(existingBins[i].tick)).to.deep.equal({
+              ...existingBins[i],
+              prev: i == 0 ? undefined : existingBins[i - 1],
+              next:
+                i == existingBins.length - 1
+                  ? state.binCache.get(tick)
+                  : existingBins[i + 1],
+            });
+          }
+
+          expect(state.bestBinInCache).to.be.equal(existingBins[0]);
+          expect(state.worstBinInCache).to.be.equal(state.binCache.get(tick));
+        });
+      });
+    });
+
+    describe(
+      SemibookCacheOperations.prototype.insertOfferDueToEvent.name,
+      () => {
+        [true, false].map((isComplete) => {
+          const isCompleteStr = isComplete ? "complete" : "incomplete";
+          describe(`${isCompleteStr} cache`, () => {
+            describe(`${isCompleteStr} empty cache`, () => {
+              let state: Semibook.State;
+              beforeEach(() => {
+                state = createEmptyState();
+                if (isComplete) {
+                  cacheOperations.markComplete(state);
+                }
+              });
+
+              if (isComplete) {
+                it("insert creates new bin", () => {
+                  // Arrange
+                  const tick = 0;
+                  const offer = makeOffer({ tick, id: 1 });
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(true);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    [offer].map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(1);
+                  expect(state.binCache.get(tick)).to.deep.equal({
+                    tick: tick,
+                    offerCount: 1,
+                    firstOfferId: offer.id,
+                    lastOfferId: offer.id,
+                    prev: undefined,
+                    next: undefined,
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(
+                    state.binCache.get(tick),
+                  );
+                  expect(state.worstBinInCache).to.be.equal(
+                    state.binCache.get(tick),
+                  );
+                });
+              } else {
+                it("insert is ignored", () => {
+                  // Arrange
+                  const tick = 0;
+                  const offer = makeOffer({ tick, id: 1 });
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(false);
+
+                  expect(state.offerCache.size).to.equal(0);
+
+                  expect(state.binCache.size).to.equal(0);
+
+                  expect(state.bestBinInCache).to.be.undefined;
+                  expect(state.worstBinInCache).to.be.undefined;
+                });
+              }
+            });
+
+            describe(`${isCompleteStr} cache with one bin`, () => {
+              let state: Semibook.State;
+              let existingBin: Semibook.Bin;
+              let existingOffers: Market.Offer[];
+              beforeEach(() => {
+                state = createEmptyState();
+
+                const tick = 0;
+                existingOffers = makeBinOffers({ tick, count: 1, fromId: 1 });
+                cacheOperations.insertCompleteBin(state, existingOffers);
+                if (isComplete) {
+                  cacheOperations.markComplete(state);
+                }
+                existingBin = state.binCache.get(tick)!;
+              });
+
+              it("offer inserted at lower tick creates new bin", () => {
+                // Arrange
+                const tick = existingBin.tick - 1;
+                const offer = makeOffer({
+                  tick,
+                  id: existingBin.lastOfferId + 1,
+                });
+
+                // Act
+                cacheOperations.insertOfferDueToEvent(state, offer);
+
+                // Assert
+                expect(state.isComplete).to.equal(isComplete);
+
+                expect([...state.offerCache.entries()]).to.deep.equal(
+                  [...existingOffers, offer].map((o) => [o.id, o]),
+                );
+
+                expect(state.binCache.size).to.equal(2);
+                expect(state.binCache.get(tick)).to.deep.equal({
+                  tick: tick,
+                  offerCount: 1,
+                  firstOfferId: offer.id,
+                  lastOfferId: offer.id,
+                  prev: undefined,
+                  next: existingBin,
+                });
+                expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                  ...existingBin,
+                  prev: state.binCache.get(tick),
+                  next: undefined,
+                });
+
+                expect(state.bestBinInCache).to.be.equal(
+                  state.binCache.get(tick),
+                );
+                expect(state.worstBinInCache).to.be.equal(existingBin);
+              });
+
+              it("offer inserted at same tick is added to the end of the bin", () => {
+                // Arrange
+                const tick = existingBin.tick;
+                const offer = makeOffer({
+                  tick,
+                  id: existingBin.lastOfferId + 1,
+                });
+
+                // Act
+                cacheOperations.insertOfferDueToEvent(state, offer);
+
+                // Assert
+                expect([...state.offerCache.entries()]).to.deep.equal(
+                  [...existingOffers, offer].map((o) => [o.id, o]),
+                );
+
+                expect(state.binCache.size).to.equal(1);
+                expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                  ...existingBin,
+                  firstOfferId: existingOffers[0].id,
+                  lastOfferId: offer.id,
+                  offerCount: existingOffers.length + 1,
+                  prev: undefined,
+                  next: undefined,
+                });
+
+                expect(state.bestBinInCache).to.be.equal(existingBin);
+                expect(state.worstBinInCache).to.be.equal(existingBin);
+              });
+
+              if (isComplete) {
+                it("offer inserted at higher tick creates new bin", () => {
+                  // Arrange
+                  const tick = existingBin.tick + 1;
+                  const offer = makeOffer({
+                    tick,
+                    id: existingBin.lastOfferId + 1,
+                  });
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(true);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    [...existingOffers, offer].map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(2);
+                  expect(state.binCache.get(tick)).to.deep.equal({
+                    tick: tick,
+                    offerCount: 1,
+                    firstOfferId: offer.id,
+                    lastOfferId: offer.id,
+                    prev: existingBin,
+                    next: undefined,
+                  });
+                  expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                    ...existingBin,
+                    prev: undefined,
+                    next: state.binCache.get(tick),
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(existingBin);
+                  expect(state.worstBinInCache).to.be.equal(
+                    state.binCache.get(tick),
+                  );
+                });
+              } else {
+                it("offer inserted at higher tick is ignored", () => {
+                  // Arrange
+                  const tick = existingBin.tick + 1;
+                  const offer = makeOffer({
+                    tick,
+                    id: existingBin.lastOfferId + 1,
+                  });
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(false);
+
+                  expect(state.offerCache.size).to.equal(existingOffers.length);
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    existingOffers.map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(1);
+                  expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                    ...existingBin,
+                    firstOfferId: existingOffers[0].id,
+                    lastOfferId: existingOffers[existingOffers.length - 1].id,
+                    offerCount: existingOffers.length,
+                    prev: undefined,
+                    next: undefined,
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(existingBin);
+                  expect(state.worstBinInCache).to.be.equal(existingBin);
+                });
+              }
+            });
+
+            describe(`${isCompleteStr} cache with multiple (3) bins`, () => {
+              let state: Semibook.State;
+              let existingBins: Semibook.Bin[];
+              let existingOffersList: Market.Offer[][];
+              beforeEach(() => {
+                state = createEmptyState();
+
+                existingBins = [];
+                existingOffersList = [];
+                for (let i = 0; i < 3; ++i) {
+                  const tick = i * 2;
+                  existingOffersList[i] = makeBinOffers({
+                    tick,
+                    count: 1,
+                    fromId: i + 1,
+                  });
+                  cacheOperations.insertCompleteBin(
+                    state,
+                    existingOffersList[i],
+                  );
+                  existingBins[i] = state.binCache.get(tick)!;
+                }
+
+                if (isComplete) {
+                  cacheOperations.markComplete(state);
+                }
+              });
+
+              it("offer inserted at lower tick creates new bin", () => {
+                // Arrange
+                const tick = existingBins[0].tick - 1;
+                const offer = makeOffer({
+                  tick,
+                  id: existingBins[existingBins.length - 1].lastOfferId + 1,
+                });
+
+                // Act
+                cacheOperations.insertOfferDueToEvent(state, offer);
+
+                // Assert
+                expect(state.isComplete).to.equal(isComplete);
+
+                expect([...state.offerCache.entries()]).to.deep.equal(
+                  [...existingOffersList.flat(), offer].map((o) => [o.id, o]),
+                );
+
+                expect(state.binCache.size).to.equal(existingBins.length + 1);
+                expect(state.binCache.get(tick)).to.deep.equal({
+                  tick: tick,
+                  offerCount: 1,
+                  firstOfferId: offer.id,
+                  lastOfferId: offer.id,
+                  prev: undefined,
+                  next: existingBins[0],
+                });
+                for (let i = 0; i < existingBins.length; ++i) {
+                  expect(
+                    state.binCache.get(existingBins[i].tick),
+                  ).to.deep.equal({
+                    ...existingBins[i],
+                    prev:
+                      i == 0 ? state.binCache.get(tick) : existingBins[i - 1],
+                    next:
+                      i == existingBins.length - 1
+                        ? undefined
+                        : existingBins[i + 1],
+                  });
+                }
+
+                expect(state.bestBinInCache).to.be.equal(
+                  state.binCache.get(tick),
+                );
+                expect(state.worstBinInCache).to.be.equal(
+                  existingBins[existingBins.length - 1],
+                );
+              });
+
+              it("offer inserted at inbetween tick creates new bin", () => {
+                // Arrange
+                const tick = existingBins[0].tick + 1;
+                const offer = makeOffer({
+                  tick,
+                  id: existingBins[existingBins.length - 1].lastOfferId + 1,
+                });
+
+                // Act
+                cacheOperations.insertOfferDueToEvent(state, offer);
+
+                // Assert
+                expect(state.isComplete).to.equal(isComplete);
+
+                expect([...state.offerCache.entries()]).to.deep.equal(
+                  [...existingOffersList.flat(), offer].map((o) => [o.id, o]),
+                );
+
+                expect(state.binCache.size).to.equal(existingBins.length + 1);
+                expect(state.binCache.get(tick)).to.deep.equal({
+                  tick: tick,
+                  offerCount: 1,
+                  firstOfferId: offer.id,
+                  lastOfferId: offer.id,
+                  prev: existingBins[0],
+                  next: existingBins[1],
+                });
+                for (let i = 0; i < existingBins.length; ++i) {
+                  expect(
+                    state.binCache.get(existingBins[i].tick),
+                  ).to.deep.equal({
+                    ...existingBins[i],
+                    prev:
+                      i == 0
+                        ? undefined
+                        : i == 1
+                          ? state.binCache.get(tick)
+                          : existingBins[i - 1],
+                    next:
+                      i == 0 ? state.binCache.get(tick) : existingBins[i + 1],
+                  });
+                }
+
+                expect(state.bestBinInCache).to.be.equal(existingBins[0]);
+                expect(state.worstBinInCache).to.be.equal(
+                  existingBins[existingBins.length - 1],
+                );
+              });
+
+              it("offer inserted at existing tick is added to the end of the bin", () => {
+                // Arrange
+                const tick = existingBins[1].tick;
+                const offer = makeOffer({
+                  tick,
+                  id: existingBins[existingBins.length - 1].lastOfferId + 1,
+                });
+
+                const binBefore = { ...state.binCache.get(tick)! };
+
+                // Act
+                cacheOperations.insertOfferDueToEvent(state, offer);
+
+                // Assert
+                expect(state.isComplete).to.equal(isComplete);
+
+                expect(state.offerCache.size).to.equal(
+                  existingOffersList.reduce(
+                    (prev, curr) => curr.length + prev,
+                    0,
+                  ) + 1,
+                );
+                expect([...state.offerCache.entries()]).to.deep.equal(
+                  [...existingOffersList.flat(), offer].map((o) => [o.id, o]),
+                );
+
+                expect(state.binCache.size).to.equal(existingBins.length);
+                expect(state.binCache.get(tick)).to.deep.equal({
+                  ...binBefore,
+                  lastOfferId: offer.id,
+                  offerCount: binBefore.offerCount + 1,
+                });
+
+                expect(state.bestBinInCache).to.be.equal(existingBins[0]);
+                expect(state.worstBinInCache).to.be.equal(
+                  existingBins[existingBins.length - 1],
+                );
+              });
+
+              if (isComplete) {
+                it("offer inserted at higher tick creates new bin", () => {
+                  // Arrange
+                  const tick = existingBins[existingBins.length - 1].tick + 1;
+                  const offer = makeOffer({
+                    tick,
+                    id: existingBins[existingBins.length - 1].lastOfferId + 1,
+                  });
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(true);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    [...existingOffersList.flat(), offer].map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(existingBins.length + 1);
+                  expect(state.binCache.get(tick)).to.deep.equal({
+                    tick: tick,
+                    offerCount: 1,
+                    firstOfferId: offer.id,
+                    lastOfferId: offer.id,
+                    prev: existingBins[existingBins.length - 1],
+                    next: undefined,
+                  });
+                  for (let i = 0; i < existingBins.length; ++i) {
+                    expect(
+                      state.binCache.get(existingBins[i].tick),
+                    ).to.deep.equal({
+                      ...existingBins[i],
+                      next:
+                        i == existingBins.length - 1
+                          ? state.binCache.get(tick)
+                          : existingBins[i + 1],
+                    });
+                  }
+
+                  expect(state.bestBinInCache).to.be.equal(existingBins[0]);
+                  expect(state.worstBinInCache).to.be.equal(
+                    state.binCache.get(tick),
+                  );
+                });
+              } else {
+                it("offer inserted at higher tick is ignored", () => {
+                  // Arrange
+                  const tick = existingBins[existingBins.length - 1].tick + 1;
+                  const offer = makeOffer({
+                    tick,
+                    id: existingBins[existingBins.length - 1].lastOfferId + 1,
+                  });
+
+                  const binsBefore = existingBins.map((bin) => ({ ...bin }));
+
+                  // Act
+                  cacheOperations.insertOfferDueToEvent(state, offer);
+
+                  // Assert
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    existingOffersList.flat().map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(existingBins.length);
+                  for (let i = 0; i < existingBins.length; ++i) {
+                    expect(
+                      state.binCache.get(existingBins[i].tick),
+                    ).to.deep.equal(binsBefore[i]);
+                  }
+
+                  expect(state.bestBinInCache).to.be.equal(existingBins[0]);
+                  expect(state.worstBinInCache).to.be.equal(
+                    existingBins[existingBins.length - 1],
+                  );
+                });
+              }
+            });
+          });
+        });
+      },
+    );
+
+    describe(
+      SemibookCacheOperations.prototype.removeOfferDueToEvent.name,
+      () => {
+        [true, false].map((isComplete) => {
+          const isCompleteStr = isComplete ? "complete" : "incomplete";
+          describe(`${isCompleteStr} cache`, () => {
+            describe(`${isCompleteStr} empty cache`, () => {
+              let state: Semibook.State;
+              beforeEach(() => {
+                state = createEmptyState();
+                if (isComplete) {
+                  cacheOperations.markComplete(state);
+                }
+              });
+
+              [true, false].map((allowUnknownId) => {
+                if (isComplete && !allowUnknownId) {
+                  it("cannot remove offer from complete, empty cache when allowUnknownId = false", () => {
+                    // Arrange
+                    const offerId = 1;
+
+                    // Act & Assert
+                    expect(() =>
+                      cacheOperations.removeOfferDueToEvent(
+                        state,
+                        offerId,
+                        allowUnknownId,
+                      ),
+                    ).to.throw();
+                  });
+                } else {
+                  it(`remove from ${isCompleteStr}, empty cache is ignored when allowUnknownId = ${allowUnknownId}`, () => {
+                    // Arrange
+                    const offerId = 1;
+
+                    // Act
+                    cacheOperations.removeOfferDueToEvent(
+                      state,
+                      offerId,
+                      allowUnknownId,
+                    );
+
+                    // Assert
+                    expect(state.isComplete).to.equal(isComplete);
+
+                    expect(state.offerCache.size).to.equal(0);
+
+                    expect(state.binCache.size).to.equal(0);
+
+                    expect(state.bestBinInCache).to.be.undefined;
+                    expect(state.worstBinInCache).to.be.undefined;
+                  });
+                }
+              });
+            });
+
+            describe(`${isCompleteStr} cache with one bin`, () => {
+              let state: Semibook.State;
+              let existingBin: Semibook.Bin;
+              let existingOffers: Market.Offer[];
+
+              describe("bin has one offer", () => {
+                beforeEach(() => {
+                  state = createEmptyState();
+
+                  const tick = 0;
+                  existingOffers = makeBinOffers({ tick, count: 1, fromId: 1 });
+                  cacheOperations.insertCompleteBin(state, existingOffers);
+                  if (isComplete) {
+                    cacheOperations.markComplete(state);
+                  }
+                  existingBin = state.binCache.get(tick)!;
+                });
+
+                [true, false].map((allowUnknownId) => {
+                  if (isComplete && !allowUnknownId) {
+                    it("cannot remove unknown offer from complete cache when allowUnknownId = false", () => {
+                      // Arrange
+                      const offerId = existingBin.lastOfferId + 1;
+
+                      // Act & Assert
+                      expect(() =>
+                        cacheOperations.removeOfferDueToEvent(
+                          state,
+                          offerId,
+                          allowUnknownId,
+                        ),
+                      ).to.throw();
+                    });
+                  } else {
+                    it(`remove from ${isCompleteStr} cache is ignored when allowUnknownId = ${allowUnknownId}`, () => {
+                      // Arrange
+                      const offerId = existingBin.lastOfferId + 1;
+
+                      // Act
+                      cacheOperations.removeOfferDueToEvent(
+                        state,
+                        offerId,
+                        allowUnknownId,
+                      );
+
+                      // Assert
+                      expect(state.isComplete).to.equal(isComplete);
+
+                      expect([...state.offerCache.entries()]).to.deep.equal(
+                        existingOffers.map((o) => [o.id, o]),
+                      );
+
+                      expect(state.binCache.size).to.equal(1);
+                      expect(
+                        state.binCache.get(existingBin.tick),
+                      ).to.deep.equal({
+                        ...existingBin,
+                        firstOfferId: existingOffers[0].id,
+                        lastOfferId:
+                          existingOffers[existingOffers.length - 1].id,
+                        offerCount: existingOffers.length,
+                        prev: undefined,
+                        next: undefined,
+                      });
+
+                      expect(state.bestBinInCache).to.be.equal(existingBin);
+                      expect(state.worstBinInCache).to.be.equal(existingBin);
+                    });
+                  }
+                });
+
+                it("remove offer ID removes offer and bin", () => {
+                  // Arrange
+                  const offerId = existingOffers[0].id;
+
+                  // Act
+                  cacheOperations.removeOfferDueToEvent(state, offerId);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(isComplete);
+
+                  expect(state.offerCache.size).to.equal(0);
+
+                  expect(state.binCache.size).to.equal(0);
+
+                  expect(state.bestBinInCache).to.be.undefined;
+                  expect(state.worstBinInCache).to.be.undefined;
+                });
+              });
+
+              describe("bin has multiple (3) offers", () => {
+                beforeEach(() => {
+                  state = createEmptyState();
+
+                  const tick = 0;
+                  existingOffers = makeBinOffers({ tick, count: 3, fromId: 1 });
+                  cacheOperations.insertCompleteBin(state, existingOffers);
+                  if (isComplete) {
+                    cacheOperations.markComplete(state);
+                  }
+                  existingBin = state.binCache.get(tick)!;
+                });
+
+                it("removes first offer ID", () => {
+                  // Arrange
+                  const offerId = existingOffers[0].id;
+
+                  // Act
+                  cacheOperations.removeOfferDueToEvent(state, offerId);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(isComplete);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    existingOffers
+                      .filter((o) => o.id != offerId)
+                      .map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(1);
+                  expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                    ...existingBin,
+                    firstOfferId: existingOffers[1].id,
+                    lastOfferId: existingOffers[existingOffers.length - 1].id,
+                    offerCount: existingOffers.length - 1,
+                    prev: undefined,
+                    next: undefined,
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(existingBin);
+                  expect(state.worstBinInCache).to.be.equal(existingBin);
+                });
+
+                it("removes middle offer ID", () => {
+                  // Arrange
+                  const offerId = existingOffers[1].id;
+
+                  // Act
+                  cacheOperations.removeOfferDueToEvent(state, offerId);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(isComplete);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    existingOffers
+                      .filter((o) => o.id != offerId)
+                      .map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(1);
+                  expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                    ...existingBin,
+                    firstOfferId: existingOffers[0].id,
+                    lastOfferId: existingOffers[existingOffers.length - 1].id,
+                    offerCount: existingOffers.length - 1,
+                    prev: undefined,
+                    next: undefined,
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(existingBin);
+                  expect(state.worstBinInCache).to.be.equal(existingBin);
+                });
+
+                it("removes last offer ID", () => {
+                  // Arrange
+                  const offerId = existingOffers[existingOffers.length - 1].id;
+
+                  // Act
+                  cacheOperations.removeOfferDueToEvent(state, offerId);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(isComplete);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    existingOffers
+                      .filter((o) => o.id != offerId)
+                      .map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(1);
+                  expect(state.binCache.get(existingBin.tick)).to.deep.equal({
+                    ...existingBin,
+                    firstOfferId: existingOffers[0].id,
+                    lastOfferId: existingOffers[existingOffers.length - 2].id,
+                    offerCount: existingOffers.length - 1,
+                    prev: undefined,
+                    next: undefined,
+                  });
+
+                  expect(state.bestBinInCache).to.be.equal(existingBin);
+                  expect(state.worstBinInCache).to.be.equal(existingBin);
+                });
+              });
+            });
+
+            describe(`${isCompleteStr} cache with multiple (3) bins, each bin has one offer`, () => {
+              let state: Semibook.State;
+              let existingBins: Semibook.Bin[];
+              let existingOffersList: Market.Offer[][];
+              beforeEach(() => {
+                state = createEmptyState();
+
+                existingBins = [];
+                existingOffersList = [];
+                for (let i = 0; i < 3; ++i) {
+                  const tick = i * 2;
+                  existingOffersList[i] = makeBinOffers({
+                    tick,
+                    count: 1,
+                    fromId: i + 1,
+                  });
+                  cacheOperations.insertCompleteBin(
+                    state,
+                    existingOffersList[i],
+                  );
+                  existingBins[i] = state.binCache.get(tick)!;
+                }
+                if (isComplete) {
+                  cacheOperations.markComplete(state);
+                }
+              });
+
+              [0, 1, 2].forEach((binIndex) => {
+                it(`removes offer from ${
+                  binIndex == 0 ? "first" : binIndex == 1 ? "middle" : "last"
+                } bin`, () => {
+                  // Arrange
+                  const offerId = existingOffersList[binIndex][0].id;
+
+                  // Act
+                  cacheOperations.removeOfferDueToEvent(state, offerId);
+
+                  // Assert
+                  expect(state.isComplete).to.equal(isComplete);
+
+                  expect([...state.offerCache.entries()]).to.deep.equal(
+                    [
+                      ...existingOffersList
+                        .flat()
+                        .filter((o) => o.id != offerId),
+                    ].map((o) => [o.id, o]),
+                  );
+
+                  expect(state.binCache.size).to.equal(existingBins.length - 1);
+                  expect(state.binCache.get(existingBins[binIndex].tick)).to.be
+                    .undefined;
+                  const remainingBins = existingBins.filter(
+                    (_, i) => i != binIndex,
+                  );
+                  for (let i = 0; i < remainingBins.length; ++i) {
+                    expect(
+                      state.binCache.get(remainingBins[i].tick),
+                    ).to.deep.equal({
+                      ...remainingBins[i],
+                      prev: i == 0 ? undefined : remainingBins[i - 1],
+                      next:
+                        i == remainingBins.length - 1
+                          ? undefined
+                          : remainingBins[i + 1],
+                    });
+                  }
+
+                  expect(state.bestBinInCache).to.be.equal(remainingBins[0]);
+                  expect(state.worstBinInCache).to.be.equal(
+                    remainingBins[remainingBins.length - 1],
+                  );
+                });
+              });
+            });
+          });
+        });
+      },
+    );
   });
 });

--- a/test/unit/semibook.unit.test.ts
+++ b/test/unit/semibook.unit.test.ts
@@ -157,8 +157,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       const offer: Market.Offer = {
         id: 1,
@@ -179,8 +179,12 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 1);
       assert.equal(state.binCache.size, 1);
-      assert.deepStrictEqual(state.bestInCache, offer.id);
-      assert.deepStrictEqual(state.worstInCache, offer.id);
+      assert.notEqual(state.bestBinInCache, undefined);
+      assert.notEqual(state.worstBinInCache, undefined);
+      assert.equal(state.bestBinInCache?.tick, offer.tick);
+      assert.deepStrictEqual(state.bestBinInCache, state.worstBinInCache);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer.id);
+      assert.deepStrictEqual(state.bestBinInCache?.lastOfferId, offer.id);
       assert.deepStrictEqual(offer.next, undefined);
       assert.deepStrictEqual(offer.prev, undefined);
     });
@@ -219,8 +223,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
 
@@ -230,22 +234,25 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer2.id);
+      assert.notDeepStrictEqual(state.bestBinInCache, state.worstBinInCache);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
       assert.deepStrictEqual(offer2.prev, undefined);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.worstBinInCache,
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
-        prev: offer1.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
+        prev: state.bestBinInCache,
         next: undefined,
       });
     });
@@ -271,8 +278,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
 
@@ -282,23 +289,26 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestInCache, offer2.id);
-      assert.deepStrictEqual(state.worstInCache, offer1.id);
+      assert.notDeepStrictEqual(state.bestBinInCache, state.worstBinInCache);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer2.id);
+      assert.deepStrictEqual(state.worstBinInCache?.firstOfferId, offer1.id);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer2.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
-        prev: offer2.tick,
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
+        prev: state.bestBinInCache,
         next: undefined,
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
         prev: undefined,
-        next: offer1.tick,
+        next: state.worstBinInCache,
       });
     });
 
@@ -333,8 +343,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
       book.insertOffer(state, offer3);
@@ -345,8 +355,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 3);
       assert.equal(state.binCache.size, 3);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer3.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
@@ -355,20 +365,23 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offer3.prev, undefined);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.binCache.get(offer2.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
-        prev: offer1.tick,
-        next: offer3.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
+        prev: state.binCache.get(offer1.tick),
+        next: state.binCache.get(offer3.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer3.tick), {
         tick: offer3.tick,
-        offers: [offer3.id],
-        prev: offer2.tick,
+        firstOfferId: offer3.id,
+        lastOfferId: offer3.id,
+        prev: state.binCache.get(offer2.tick),
         next: undefined,
       });
     });
@@ -409,8 +422,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       book.insertOffer(state, offer1);
@@ -423,8 +436,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 4);
       assert.equal(state.binCache.size, 3);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer3.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, offer4.id);
@@ -435,20 +448,23 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offer4.prev, offer2.id);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.binCache.get(offer2.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id, offer4.id],
-        prev: offer1.tick,
-        next: offer3.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer4.id,
+        prev: state.binCache.get(offer1.tick),
+        next: state.binCache.get(offer3.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer3.tick), {
         tick: offer3.tick,
-        offers: [offer3.id],
-        prev: offer2.tick,
+        firstOfferId: offer3.id,
+        lastOfferId: offer3.id,
+        prev: state.binCache.get(offer2.tick),
         next: undefined,
       });
     });
@@ -484,8 +500,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       book.insertOffer(state, offer1);
@@ -497,8 +513,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 3);
       assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer3.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer3.id);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, offer3.id);
@@ -507,14 +523,16 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offer3.prev, offer2.id);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.binCache.get(offer2.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id, offer3.id],
-        prev: offer1.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer3.id,
+        prev: state.binCache.get(offer1.tick),
         next: undefined,
       });
     });
@@ -550,8 +568,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       book.insertOffer(state, offer1);
@@ -564,8 +582,8 @@ describe("Semibook unit test suite", () => {
       assert.equal(state.offerCache.size, 3);
       assert.equal(state.binCache.size, 2);
 
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer2.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
       assert.deepStrictEqual(offer1.next, offer3.id);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
@@ -574,14 +592,16 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offer3.prev, offer1.id);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id, offer3.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer3.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.binCache.get(offer2.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
-        prev: offer1.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
+        prev: state.binCache.get(offer1.tick),
         next: undefined,
       });
     });
@@ -607,8 +627,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       const options = { maxOffers: 5 };
@@ -652,8 +672,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       const options = { maxOffers: 5 };
@@ -685,8 +705,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: 0,
-        worstInCache: 0,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       //Act
       const offerRemoved = book.removeOffer(state, 1);
@@ -729,8 +749,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
       book.insertOffer(state, offer2);
@@ -742,8 +762,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer2.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
@@ -751,14 +771,16 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offerRemoved, offer3);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
         prev: undefined,
-        next: offer2.tick,
+        next: state.binCache.get(offer2.tick),
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
-        prev: offer1.tick,
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
+        prev: state.binCache.get(offer1.tick),
         next: undefined,
       });
     });
@@ -795,8 +817,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
       book.insertOffer(state, offer2);
@@ -808,8 +830,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 1);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer2.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
       assert.deepStrictEqual(offer1.next, offer2.id);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer2.next, undefined);
@@ -817,7 +839,8 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offerRemoved, offer3);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id, offer2.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer2.id,
         prev: undefined,
         next: undefined,
       });
@@ -856,8 +879,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
       book.insertOffer(state, offer2);
@@ -869,8 +892,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 2);
-      assert.deepStrictEqual(state.bestInCache, offer2.id);
-      assert.deepStrictEqual(state.worstInCache, offer1.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer2.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer1.id);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer1.next, undefined);
       assert.deepStrictEqual(offer2.prev, undefined);
@@ -878,15 +901,17 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offerRemoved, offer3);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id],
-        prev: offer2.tick,
+        firstOfferId: offer1.id,
+        lastOfferId: offer1.id,
+        prev: state.binCache.get(offer2.tick),
         next: undefined,
       });
       assert.deepStrictEqual(state.binCache.get(offer2.tick), {
         tick: offer2.tick,
-        offers: [offer2.id],
+        firstOfferId: offer2.id,
+        lastOfferId: offer2.id,
         prev: undefined,
-        next: offer1.tick,
+        next: state.binCache.get(offer1.tick),
       });
     });
 
@@ -922,8 +947,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer1);
       book.insertOffer(state, offer2);
@@ -935,8 +960,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 2);
       assert.equal(state.binCache.size, 1);
-      assert.deepStrictEqual(state.bestInCache, offer1.id);
-      assert.deepStrictEqual(state.worstInCache, offer2.id);
+      assert.deepStrictEqual(state.bestBinInCache?.firstOfferId, offer1.id);
+      assert.deepStrictEqual(state.worstBinInCache?.lastOfferId, offer2.id);
       assert.deepStrictEqual(offer1.prev, undefined);
       assert.deepStrictEqual(offer1.next, offer2.id);
       assert.deepStrictEqual(offer2.prev, offer1.id);
@@ -944,7 +969,8 @@ describe("Semibook unit test suite", () => {
       assert.deepStrictEqual(offerRemoved, offer3);
       assert.deepStrictEqual(state.binCache.get(offer1.tick), {
         tick: offer1.tick,
-        offers: [offer1.id, offer2.id],
+        firstOfferId: offer1.id,
+        lastOfferId: offer2.id,
         prev: undefined,
         next: undefined,
       });
@@ -971,8 +997,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       book.insertOffer(state, offer);
 
@@ -982,8 +1008,8 @@ describe("Semibook unit test suite", () => {
       // Assert
       assert.equal(state.offerCache.size, 0);
       assert.equal(state.binCache.size, 0);
-      assert.deepStrictEqual(state.bestInCache, undefined);
-      assert.deepStrictEqual(state.worstInCache, undefined);
+      assert.deepStrictEqual(state.bestBinInCache, undefined);
+      assert.deepStrictEqual(state.worstBinInCache, undefined);
       assert.deepStrictEqual(offerRemoved, offer);
     });
   });
@@ -995,8 +1021,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
       //Act
 
@@ -1027,8 +1053,8 @@ describe("Semibook unit test suite", () => {
       const state: Semibook.State = {
         offerCache: new Map(),
         binCache: new Map(),
-        bestInCache: undefined,
-        worstInCache: undefined,
+        bestBinInCache: undefined,
+        worstBinInCache: undefined,
       };
 
       book.insertOffer(state, offer);


### PR DESCRIPTION
The Semibook cache now maintains consistency. After the upgrade to Mangrove v2, the cache could become inconsistent as it was not ensuring that added offers were an extension of the prefix held in the case. This has been fixed.

The Semibook cache now holds complete tick bins: If one offer with a given tick is in the cache, all offers with that tick is in the cache.

The `maxOffers` option in `CacheContentOptions` has been replaced with a new option: `targetNumberOfTicks`.  When loading from chain, the cache will load until at least this number of ticks is in the cache. The default is `Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS`.

A new default value `Semibook.DEFAULT_CHUNK_SIZE` has been introduced for `CacheContentOptions.chunkSize`.