### PR TITLE
feat: Cache global and local configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 - feat!: Rename tick parameters of 'Market.simulateGas' and 'Semibook.simulateMarketOrder' to 'maxTick'.
 - fix: Semibook now maintains consistency. After the upgrade to Mangrove v2, the cache could become inconsistent as it was not ensuring that added offers were an extension of the prefix held in the case.
 - feat: Semibook cache now holds complete tick bins: If one offer with a given tick is in the cache, all offers with that tick is in the cache.
-- feat!: The `maxOffers` option in `CacheContentOptions` has been replaced with a new option: `targetNumberOfTicks`. When loading from chain, the cache will load until at least this number of ticks is in the cache. The default is `Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS`.
-- feat!: A new default value `Semibook.DEFAULT_CHUNK_SIZE` has been introduced for `CacheContentOptions.chunkSize`.
+- feat!: The 'maxOffers' option in 'CacheContentOptions' has been replaced with a new option: 'targetNumberOfTicks'. When loading from chain, the cache will load until at least this number of ticks is in the cache. The default is 'Semibook.DEFAULT_TARGET_NUMBER_OF_TICKS'.
+- feat!: A new default value 'Semibook.DEFAULT_CHUNK_SIZE' has been introduced for 'CacheContentOptions.chunkSize'.
+- feat!: Mangrove and Semibook configs are now cached on 'connect' and (for Semibook) updated by events. The methods to read configs are no longer async and naming has been made consistent: 'Mangrove.config()', 'Market.config()', and 'Semibook.config()'.
+- feat: Two missing global config fields have been added: 'maxRecursionDepth' and 'maxGasreqForFailingOffers'.
+- feat!: All order book events now carry the relevant data for the event. And events that are not related to offers do not carry offer data.
 
 # 2.0.0-12
 

--- a/src/kandel/kandelSeeder.ts
+++ b/src/kandel/kandelSeeder.ts
@@ -154,7 +154,7 @@ class KandelSeeder {
    * @returns The gasprice for the Kandel type multiplied by the buffer factor.
    */
   public async getBufferedGasprice(gaspriceFactor: number, gasprice?: number) {
-    return gaspriceFactor * (gasprice ?? (await this.mgv.config()).gasprice);
+    return gaspriceFactor * (gasprice ?? this.mgv.config().gasprice);
   }
 
   /** Determines the required provision for the distribution prior to sowing based on the number of price points.
@@ -199,7 +199,7 @@ class KandelSeeder {
     factor?: number;
   }) {
     const gasreq = await this.getDefaultGasreq(params.onAave);
-    return await this.getMinimumVolumeForGasreq({ ...params, gasreq });
+    return this.getMinimumVolumeForGasreq({ ...params, gasreq });
   }
 
   /** Determines the minimum recommended volume for an offer of the given type to avoid density issues.
@@ -210,7 +210,7 @@ class KandelSeeder {
    * @param params.gasreq The gasreq to use.
    * @returns The minimum recommended volume.
    */
-  public async getMinimumVolumeForGasreq(params: {
+  public getMinimumVolumeForGasreq(params: {
     market: Market;
     offerType: Market.BA;
     factor?: number;
@@ -218,16 +218,15 @@ class KandelSeeder {
   }) {
     const config = this.configuration.getConfig(params.market);
 
-    return (
-      await params.market
-        .getSemibook(params.offerType)
-        .getMinimumVolume(params.gasreq)
-    ).mul(
-      params.factor ??
-        (params.offerType == "asks"
-          ? config.minimumBasePerOfferFactor
-          : config.minimumQuotePerOfferFactor),
-    );
+    return params.market
+      .getSemibook(params.offerType)
+      .getMinimumVolume(params.gasreq)
+      .mul(
+        params.factor ??
+          (params.offerType == "asks"
+            ? config.minimumBasePerOfferFactor
+            : config.minimumQuotePerOfferFactor),
+      );
   }
 }
 

--- a/src/liquidityProvider.ts
+++ b/src/liquidityProvider.ts
@@ -322,7 +322,7 @@ class LiquidityProvider {
     return this.#constructPromise(
       this.market,
       (_cbArg, _bookEvent, _ethersLog) => ({
-        id: _cbArg.offerId as number,
+        id: _cbArg.type === "OfferWrite" ? (_cbArg.offerId as number) : 0,
         event: _ethersLog as ethers.providers.Log,
       }),
       txPromise as Promise<ethers.ContractTransaction>,

--- a/src/mangrove.ts
+++ b/src/mangrove.ts
@@ -65,6 +65,8 @@ namespace Mangrove {
     gasprice: number;
     gasmax: number;
     dead: boolean;
+    maxRecursionDepth: number;
+    maxGasreqForFailingOffers: number;
   };
 
   export type SimplePermitData = {
@@ -687,6 +689,8 @@ class Mangrove {
       gasprice: config.gasprice.toNumber(),
       gasmax: config.gasmax.toNumber(),
       dead: config.dead,
+      maxRecursionDepth: config.maxRecursionDepth.toNumber(),
+      maxGasreqForFailingOffers: config.maxGasreqForFailingOffers.toNumber(),
     };
   }
 

--- a/src/mangrove.ts
+++ b/src/mangrove.ts
@@ -23,7 +23,6 @@ Big.prototype[Symbol.for("nodejs.util.inspect.custom")] =
    use Mangrove.connect to make sure the network is reached during construction */
 let canConstructMangrove = false;
 
-import type { Awaited } from "ts-essentials";
 import {
   BlockManager,
   ReliableProvider,
@@ -34,7 +33,6 @@ import { JsonRpcProvider, WebSocketProvider } from "@ethersproject/providers";
 import MangroveEventSubscriber from "./mangroveEventSubscriber";
 import { onEthersError } from "./util/ethersErrorHandler";
 import EventEmitter from "events";
-import { LocalUnpackedStructOutput } from "./types/typechain/MgvReader";
 import { OLKeyStruct } from "./types/typechain/Mangrove";
 import { Density } from "./util/Density";
 
@@ -49,6 +47,9 @@ namespace Mangrove {
     fee: number;
     density: Density;
     offer_gasbase: number;
+  };
+
+  export type LocalConfigFull = LocalConfig & {
     lock: boolean;
     last: number | undefined;
     binPosInLeaf: number;
@@ -123,7 +124,8 @@ class Mangrove {
   olKeyStructToOlKeyHashMap: Map<string, string> = new Map();
   nativeToken: TokenCalculations;
 
-  public eventEmitter: EventEmitter;
+  eventEmitter: EventEmitter;
+  _config: Mangrove.GlobalConfig; // TODO: This should be made reorg resistant
 
   static devNode: DevNode;
   static typechain = typechain;
@@ -205,6 +207,31 @@ class Mangrove {
         onError: onEthersError(eventEmitter),
       };
     }
+
+    const multicallContract = typechain.Multicall2__factory.connect(
+      Mangrove.getAddress("Multicall2", network.name),
+      signer,
+    );
+
+    const address = Mangrove.getAddress("Mangrove", network.name);
+    const contract = typechain.IMangrove__factory.connect(address, signer);
+
+    const readerAddress = Mangrove.getAddress("MgvReader", network.name);
+    const readerContract = typechain.MgvReader__factory.connect(
+      readerAddress,
+      signer,
+    );
+
+    const orderAddress = Mangrove.getAddress("MangroveOrder", network.name);
+    const orderContract = typechain.MangroveOrder__factory.connect(
+      orderAddress,
+      signer,
+    );
+
+    const config = Mangrove.rawConfigToConfig(
+      await readerContract.globalUnpacked(),
+    );
+
     canConstructMangrove = true;
     const mgv = new Mangrove({
       signer: signer,
@@ -224,6 +251,12 @@ class Mangrove {
           }
         : undefined,
       shouldNotListenToNewEvents: options.shouldNotListenToNewEvents,
+      multicallContract,
+      address,
+      contract,
+      readerContract,
+      orderContract,
+      config,
     });
 
     await mgv.initializeProvider();
@@ -271,6 +304,12 @@ class Mangrove {
       wsUrl: string;
     };
     shouldNotListenToNewEvents?: boolean;
+    multicallContract: typechain.Multicall2;
+    address: string;
+    contract: typechain.IMangrove;
+    readerContract: typechain.MgvReader;
+    orderContract: typechain.MangroveOrder;
+    config: Mangrove.GlobalConfig;
   }) {
     if (!canConstructMangrove) {
       throw Error(
@@ -287,29 +326,12 @@ class Mangrove {
     this.signer = params.signer;
     this.network = params.network;
     this._readOnly = params.readOnly;
-    this.multicallContract = typechain.Multicall2__factory.connect(
-      Mangrove.getAddress("Multicall2", this.network.name),
-      this.signer,
-    );
-    this.address = Mangrove.getAddress("Mangrove", this.network.name);
-    this.contract = typechain.IMangrove__factory.connect(
-      this.address,
-      this.signer,
-    );
-    const readerAddress = Mangrove.getAddress("MgvReader", this.network.name);
-    this.readerContract = typechain.MgvReader__factory.connect(
-      readerAddress,
-      this.signer,
-    );
-
-    const orderAddress = Mangrove.getAddress(
-      "MangroveOrder",
-      this.network.name,
-    );
-    this.orderContract = typechain.MangroveOrder__factory.connect(
-      orderAddress,
-      this.signer,
-    );
+    this.multicallContract = params.multicallContract;
+    this.address = params.address;
+    this.contract = params.contract;
+    this.readerContract = params.readerContract;
+    this.orderContract = params.orderContract;
+    this._config = params.config;
 
     this.shouldNotListenToNewEvents = false;
     if (params.shouldNotListenToNewEvents) {
@@ -677,20 +699,33 @@ class Mangrove {
   }
 
   /**
-   * Return global Mangrove config
+   * Return global Mangrove config from cache.
    */
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  async config(): Promise<Mangrove.GlobalConfig> {
-    const config = await this.readerContract.globalUnpacked();
+  config(): Mangrove.GlobalConfig {
+    return this._config;
+  }
+
+  /**
+   * Return global Mangrove config from chain.
+   */
+  async fetchConfig(): Promise<Mangrove.GlobalConfig> {
+    return Mangrove.rawConfigToConfig(
+      await this.readerContract.globalUnpacked(),
+    );
+  }
+
+  static rawConfigToConfig(
+    rawConfig: Mangrove.RawConfig["_global"],
+  ): Mangrove.GlobalConfig {
     return {
-      monitor: config.monitor,
-      useOracle: config.useOracle,
-      notify: config.notify,
-      gasprice: config.gasprice.toNumber(),
-      gasmax: config.gasmax.toNumber(),
-      dead: config.dead,
-      maxRecursionDepth: config.maxRecursionDepth.toNumber(),
-      maxGasreqForFailingOffers: config.maxGasreqForFailingOffers.toNumber(),
+      monitor: rawConfig.monitor,
+      useOracle: rawConfig.useOracle,
+      notify: rawConfig.notify,
+      gasprice: rawConfig.gasprice.toNumber(),
+      gasmax: rawConfig.gasmax.toNumber(),
+      dead: rawConfig.dead,
+      maxRecursionDepth: rawConfig.maxRecursionDepth.toNumber(),
+      maxGasreqForFailingOffers: rawConfig.maxGasreqForFailingOffers.toNumber(),
     };
   }
 
@@ -880,7 +915,7 @@ class Mangrove {
       string,
       {
         token: Token;
-        configs: Record<string, LocalUnpackedStructOutput>;
+        configs: Record<string, Mangrove.RawConfig["_local"]>;
       }
     > = {};
 

--- a/src/mangroveEventSubscriber.ts
+++ b/src/mangroveEventSubscriber.ts
@@ -15,8 +15,10 @@ const BookSubscriptionEventsSet = new Set([
   "OfferSuccess",
   "OfferSuccessWithPosthookData",
   "OfferRetract",
-  "SetGasbase",
   "SetActive",
+  "SetFee",
+  "SetGasbase",
+  "SetDensity96X32",
 ]);
 
 class MangroveEventSubscriber extends LogSubscriber<Market.BookSubscriptionEvent> {

--- a/src/market.ts
+++ b/src/market.ts
@@ -17,6 +17,7 @@ for more on big.js vs decimals.js vs. bignumber.js (which is *not* ethers's BigN
   github.com/MikeMcl/big.js/issues/45#issuecomment-104211175
 */
 import Big from "big.js";
+import { Density } from "./util/Density";
 
 let canConstructMarket = false;
 
@@ -124,15 +125,6 @@ namespace Market {
   > & {
     summary: CleanSummary;
   };
-
-  export type BookSubscriptionEvent =
-    | ({ name: "OfferWrite" } & TCM.OfferWriteEvent)
-    | ({ name: "OfferFail" } & TCM.OfferFailEvent)
-    | ({ name: "OfferFailWithPosthookData" } & TCM.OfferFailEvent)
-    | ({ name: "OfferSuccess" } & TCM.OfferSuccessEvent)
-    | ({ name: "OfferSuccessWithPosthookData" } & TCM.OfferSuccessEvent)
-    | ({ name: "OfferRetract" } & TCM.OfferRetractEvent)
-    | ({ name: "SetGasbase" } & TCM.SetGasbaseEvent);
 
   export type OrderRoute = "Mangrove" | "MangroveOrder";
 
@@ -265,35 +257,70 @@ namespace Market {
     export type Details = _BookReturns[3];
   }
 
+  export type BookSubscriptionEvent =
+    | ({ name: "OfferWrite" } & TCM.OfferWriteEvent)
+    | ({ name: "OfferFail" } & TCM.OfferFailEvent)
+    | ({ name: "OfferFailWithPosthookData" } & TCM.OfferFailEvent)
+    | ({ name: "OfferSuccess" } & TCM.OfferSuccessEvent)
+    | ({ name: "OfferSuccessWithPosthookData" } & TCM.OfferSuccessEvent)
+    | ({ name: "OfferRetract" } & TCM.OfferRetractEvent)
+    | ({ name: "SetActive" } & TCM.SetActiveEvent)
+    | ({ name: "SetFee" } & TCM.SetFeeEvent)
+    | ({ name: "SetGasbase" } & TCM.SetGasbaseEvent)
+    | ({ name: "SetDensity96X32" } & TCM.SetDensity96X32Event);
+
   export type BookSubscriptionCbArgument = {
     ba: Market.BA;
-    offerId?: number;
-    offer?: Offer; // if undefined, offer was not found/inserted in local cache
   } & (
-    | { type: "OfferWrite" }
     | {
-        type: "OfferFail";
-        taker: string;
-        takerWants: Big;
-        takerGives: Big;
-        mgvData: string;
+        type: "SetActive";
+        active: boolean;
       }
     | {
-        type: "OfferFailWithPosthookData";
-        taker: string;
-        takerWants: Big;
-        takerGives: Big;
-        mgvData: string;
+        type: "SetFee";
+        fee: number;
       }
-    | { type: "OfferSuccess"; taker: string; takerWants: Big; takerGives: Big }
     | {
-        type: "OfferSuccessWithPosthookData";
-        taker: string;
-        takerWants: Big;
-        takerGives: Big;
+        type: "SetGasbase";
+        offerGasbase: number;
       }
-    | { type: "OfferRetract" }
-    | { type: "SetGasbase" }
+    | {
+        type: "SetDensity96X32";
+        density: Density;
+      }
+    | ({
+        offerId?: number;
+        offer?: Offer; // if undefined, offer was not found/inserted in local cache
+      } & (
+        | { type: "OfferWrite" }
+        | {
+            type: "OfferFail";
+            taker: string;
+            takerWants: Big;
+            takerGives: Big;
+            mgvData: string;
+          }
+        | {
+            type: "OfferFailWithPosthookData";
+            taker: string;
+            takerWants: Big;
+            takerGives: Big;
+            mgvData: string;
+          }
+        | {
+            type: "OfferSuccess";
+            taker: string;
+            takerWants: Big;
+            takerGives: Big;
+          }
+        | {
+            type: "OfferSuccessWithPosthookData";
+            taker: string;
+            takerWants: Big;
+            takerGives: Big;
+          }
+        | { type: "OfferRetract" }
+      ))
   );
 
   export type MarketCallback<T> = (
@@ -383,7 +410,7 @@ class Market {
     } else {
       await market.#initialize(params.bookOptions);
     }
-    const config = await market.config();
+    const config = market.config();
     const gasreq = configuration.mangroveOrder.getRestingOrderGasreq(
       market.mgv.network.name,
     );
@@ -579,8 +606,8 @@ class Market {
     };
   }
 
-  async isActive(): Promise<boolean> {
-    const config = await this.config();
+  isActive(): boolean {
+    const config = this.config();
     return config.asks.active && config.bids.active;
   }
 
@@ -815,7 +842,7 @@ class Market {
 
   async estimateGas(bs: Market.BS, volume: BigNumber): Promise<BigNumber> {
     const semibook = this.getSemibook(this.trade.bsToBa(bs));
-    const { density, offer_gasbase } = await semibook.getConfig();
+    const { density, offer_gasbase } = semibook.config();
 
     const maxGasreqOffer = (await semibook.getMaxGasReq()) ?? 0;
     const maxMarketOrderGas: BigNumber = BigNumber.from(MAX_MARKET_ORDER_GAS);
@@ -917,15 +944,13 @@ class Market {
    * density is converted to public token units per gas used
    * fee *remains* in basis points of the token being bought
    */
-  async config(): Promise<{
+  config(): {
     asks: Mangrove.LocalConfig;
     bids: Mangrove.LocalConfig;
-  }> {
-    const asksConfigPromise = this.getSemibook("asks").getConfig();
-    const bidsConfigPromise = this.getSemibook("bids").getConfig();
+  } {
     return {
-      asks: await asksConfigPromise,
-      bids: await bidsConfigPromise,
+      asks: this.getSemibook("asks").config(),
+      bids: this.getSemibook("bids").config(),
     };
   }
 

--- a/src/semibook.ts
+++ b/src/semibook.ts
@@ -295,10 +295,7 @@ class Semibook
 
     const clonedLocalConfig = {
       ...state.localConfig,
-      density: new Density(
-        state.localConfig.density.rawDensity,
-        state.localConfig.density.outboundDecimals,
-      ),
+      density: state.localConfig.density.clone(),
     };
 
     return {

--- a/src/util/Density.ts
+++ b/src/util/Density.ts
@@ -8,8 +8,8 @@ const _2pow32 = Big(2).pow(32);
  * Utility wrapper around raw Density values from Mangrove.
  */
 export class Density {
-  #rawDensity: BigNumber;
-  #outboundDecimals: number;
+  rawDensity: BigNumber;
+  outboundDecimals: number;
 
   /**
    * Construct a wrapper around a raw Density from Mangrove.
@@ -18,11 +18,11 @@ export class Density {
    * @param outboundDecimals number of decimals for the outbound token
    */
   constructor(rawDensity: BigNumberish, outboundDecimals: number) {
-    this.#rawDensity = BigNumber.from(rawDensity);
-    if (!this.#rawDensity.and(DensityLib.MASK).eq(this.#rawDensity)) {
+    this.rawDensity = BigNumber.from(rawDensity);
+    if (!this.rawDensity.and(DensityLib.MASK).eq(this.rawDensity)) {
       throw new Error("Given density is too big");
     }
-    this.#outboundDecimals = outboundDecimals;
+    this.outboundDecimals = outboundDecimals;
   }
 
   /**
@@ -50,8 +50,8 @@ export class Density {
    */
   eq(density: Density): boolean {
     return (
-      this.#rawDensity.eq(density.#rawDensity) &&
-      this.#outboundDecimals === density.#outboundDecimals
+      this.rawDensity.eq(density.rawDensity) &&
+      this.outboundDecimals === density.outboundDecimals
     );
   }
 
@@ -61,7 +61,7 @@ export class Density {
    * @returns the density formatted as a 'mantissa * 2^exponent' string
    */
   toString(): string {
-    return Density.toString(this.#rawDensity);
+    return Density.toString(this.rawDensity);
   }
 
   /**
@@ -101,7 +101,7 @@ export class Density {
    * @returns true if the density is zero; false otherwise
    */
   isZero(): boolean {
-    return this.#rawDensity.isZero();
+    return this.rawDensity.isZero();
   }
 
   /**
@@ -112,8 +112,8 @@ export class Density {
    */
   getRequiredOutboundForGas(gas: BigNumberish): Big {
     return Big(
-      DensityLib.multiplyUp(this.#rawDensity, BigNumber.from(gas)).toString(),
-    ).div(Big(10).pow(this.#outboundDecimals));
+      DensityLib.multiplyUp(this.rawDensity, BigNumber.from(gas)).toString(),
+    ).div(Big(10).pow(this.outboundDecimals));
   }
 
   /**
@@ -123,7 +123,7 @@ export class Density {
    * @returns the maximum amount of gas an offer may require for the given raw amount of outbound tokens
    */
   getMaximumGasForRawOutbound(rawOutboundAmt: BigNumberish): BigNumber {
-    const density96X32 = DensityLib.to96X32(this.#rawDensity);
+    const density96X32 = DensityLib.to96X32(this.rawDensity);
     const densityDecimal = Big(density96X32.toString()).div(_2pow32);
     return BigNumber.from(
       Big(BigNumber.from(rawOutboundAmt).toString())

--- a/src/util/Density.ts
+++ b/src/util/Density.ts
@@ -8,8 +8,8 @@ const _2pow32 = Big(2).pow(32);
  * Utility wrapper around raw Density values from Mangrove.
  */
 export class Density {
-  rawDensity: BigNumber;
-  outboundDecimals: number;
+  #rawDensity: BigNumber;
+  #outboundDecimals: number;
 
   /**
    * Construct a wrapper around a raw Density from Mangrove.
@@ -18,11 +18,16 @@ export class Density {
    * @param outboundDecimals number of decimals for the outbound token
    */
   constructor(rawDensity: BigNumberish, outboundDecimals: number) {
-    this.rawDensity = BigNumber.from(rawDensity);
-    if (!this.rawDensity.and(DensityLib.MASK).eq(this.rawDensity)) {
+    this.#rawDensity = BigNumber.from(rawDensity);
+    if (!this.#rawDensity.and(DensityLib.MASK).eq(this.#rawDensity)) {
       throw new Error("Given density is too big");
     }
-    this.outboundDecimals = outboundDecimals;
+    this.#outboundDecimals = outboundDecimals;
+  }
+
+  /** Create a copy of this Density object. */
+  clone(): Density {
+    return new Density(this.#rawDensity, this.#outboundDecimals);
   }
 
   /**
@@ -50,8 +55,8 @@ export class Density {
    */
   eq(density: Density): boolean {
     return (
-      this.rawDensity.eq(density.rawDensity) &&
-      this.outboundDecimals === density.outboundDecimals
+      this.#rawDensity.eq(density.#rawDensity) &&
+      this.#outboundDecimals === density.#outboundDecimals
     );
   }
 
@@ -61,7 +66,7 @@ export class Density {
    * @returns the density formatted as a 'mantissa * 2^exponent' string
    */
   toString(): string {
-    return Density.toString(this.rawDensity);
+    return Density.toString(this.#rawDensity);
   }
 
   /**
@@ -101,7 +106,7 @@ export class Density {
    * @returns true if the density is zero; false otherwise
    */
   isZero(): boolean {
-    return this.rawDensity.isZero();
+    return this.#rawDensity.isZero();
   }
 
   /**
@@ -112,8 +117,8 @@ export class Density {
    */
   getRequiredOutboundForGas(gas: BigNumberish): Big {
     return Big(
-      DensityLib.multiplyUp(this.rawDensity, BigNumber.from(gas)).toString(),
-    ).div(Big(10).pow(this.outboundDecimals));
+      DensityLib.multiplyUp(this.#rawDensity, BigNumber.from(gas)).toString(),
+    ).div(Big(10).pow(this.#outboundDecimals));
   }
 
   /**
@@ -123,7 +128,7 @@ export class Density {
    * @returns the maximum amount of gas an offer may require for the given raw amount of outbound tokens
    */
   getMaximumGasForRawOutbound(rawOutboundAmt: BigNumberish): BigNumber {
-    const density96X32 = DensityLib.to96X32(this.rawDensity);
+    const density96X32 = DensityLib.to96X32(this.#rawDensity);
     const densityDecimal = Big(density96X32.toString()).div(_2pow32);
     return BigNumber.from(
       Big(BigNumber.from(rawOutboundAmt).toString())

--- a/src/util/test/TestMaker.ts
+++ b/src/util/test/TestMaker.ts
@@ -187,7 +187,7 @@ class TestMaker {
     return this.#constructPromise(
       this.market,
       (_cbArg, _bookEvent, _ethersLog) => ({
-        id: _cbArg.offerId as number,
+        id: _cbArg.type == "OfferWrite" ? (_cbArg.offerId as number) : 0,
         event: _ethersLog as Log,
       }),
       txPromise,

--- a/test/integration/kandel/seeder.integration.test.ts
+++ b/test/integration/kandel/seeder.integration.test.ts
@@ -132,7 +132,7 @@ describe(`${KandelSeeder.prototype.constructor.name} integration tests suite`, f
             await distribution.getRequiredProvision({
               market,
               gasreq: params.gasreq,
-              gasprice: (await mgv.config()).gasprice * 2,
+              gasprice: mgv.config().gasprice * 2,
             })
           ).toNumber(),
         );

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -175,31 +175,17 @@ describe("Market integration tests suite", () => {
         fee: 0,
         density: new Density(BigNumber.from(2), market.base.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
       const bids: Mangrove.LocalConfig = {
         active: true,
         fee: 0,
         density: new Density(BigNumber.from(2), market.quote.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
 
-      mockito.when(mockedMarket.config()).thenResolve({ asks, bids });
+      mockito.when(mockedMarket.config()).thenReturn({ asks, bids });
       // Act
-      const isActive = await market.isActive();
+      const isActive = market.isActive();
       // Assert
       expect(isActive).to.be.equal(true);
     });
@@ -211,7 +197,7 @@ describe("Market integration tests suite", () => {
         tickSpacing: 1,
       });
       assert.ok(
-        !(await market.isActive()),
+        !market.isActive(),
         "market is not existing and thus not active",
       );
     });
@@ -229,31 +215,17 @@ describe("Market integration tests suite", () => {
         fee: 0,
         density: new Density(BigNumber.from(2), market.base.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
       const bids: Mangrove.LocalConfig = {
         active: false,
         fee: 0,
         density: new Density(BigNumber.from(2), market.quote.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
 
-      mockito.when(mockedMarket.config()).thenResolve({ asks, bids });
+      mockito.when(mockedMarket.config()).thenReturn({ asks, bids });
       // Act
-      const isActive = await market.isActive();
+      const isActive = market.isActive();
       // Assert
       expect(isActive).to.be.equal(false);
     });
@@ -271,31 +243,17 @@ describe("Market integration tests suite", () => {
         fee: 0,
         density: new Density(BigNumber.from(2), market.base.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
       const bids: Mangrove.LocalConfig = {
         active: false,
         fee: 0,
         density: new Density(BigNumber.from(2), market.quote.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
 
-      mockito.when(mockedMarket.config()).thenResolve({ asks, bids });
+      mockito.when(mockedMarket.config()).thenReturn({ asks, bids });
       // Act
-      const isActive = await market.isActive();
+      const isActive = market.isActive();
       // Assert
       expect(isActive).to.be.equal(false);
     });
@@ -313,31 +271,17 @@ describe("Market integration tests suite", () => {
         fee: 0,
         density: new Density(BigNumber.from(2), market.base.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
       const bids: Mangrove.LocalConfig = {
         active: true,
         fee: 0,
         density: new Density(BigNumber.from(2), market.quote.decimals),
         offer_gasbase: 0,
-        lock: false,
-        last: undefined,
-        binPosInLeaf: 1,
-        root: 1,
-        level1: BigNumber.from(1),
-        level2: BigNumber.from(1),
-        level3: BigNumber.from(1),
       };
 
-      mockito.when(mockedMarket.config()).thenResolve({ asks, bids });
+      mockito.when(mockedMarket.config()).thenReturn({ asks, bids });
       // Act
-      const isActive = await market.isActive();
+      const isActive = market.isActive();
       // Assert
       expect(isActive).to.be.equal(false);
     });
@@ -439,12 +383,12 @@ describe("Market integration tests suite", () => {
           tickSpacing: 1,
         });
         const gasreq = 10000;
-        const config = await market.config();
+        const config = market.config();
         const gasbase = (ba == "asks" ? config.asks : config.bids)
           .offer_gasbase;
 
         const mgvProvision = mgv.calculateOfferProvision(
-          gasprice ?? (await mgv.config()).gasprice,
+          gasprice ?? mgv.config().gasprice,
           gasreq,
           gasbase,
         );
@@ -460,12 +404,12 @@ describe("Market integration tests suite", () => {
           : market.getBidProvision(gasreq, gasprice));
         const offersProvision = market.mgv.calculateOffersProvision([
           {
-            gasprice: gasprice ?? (await mgv.config()).gasprice,
+            gasprice: gasprice ?? mgv.config().gasprice,
             gasreq,
             gasbase,
           },
           {
-            gasprice: gasprice ?? (await mgv.config()).gasprice,
+            gasprice: gasprice ?? mgv.config().gasprice,
             gasreq,
             gasbase,
           },
@@ -780,10 +724,10 @@ describe("Market integration tests suite", () => {
       id: 1,
       prev: undefined,
       next: undefined,
-      gasprice: (await mgv.config()).gasprice,
+      gasprice: mgv.config().gasprice,
       gasreq: 10000,
       maker: await mgv.signer.getAddress(),
-      offer_gasbase: (await market.config()).asks.offer_gasbase,
+      offer_gasbase: market.config().asks.offer_gasbase,
       tick: tick,
       gives: asksGives,
       price: askPrice,
@@ -811,10 +755,10 @@ describe("Market integration tests suite", () => {
       id: 1,
       prev: undefined,
       next: undefined,
-      gasprice: (await mgv.config()).gasprice,
+      gasprice: mgv.config().gasprice,
       gasreq: 10000,
       maker: await mgv.signer.getAddress(),
-      offer_gasbase: (await market.config()).bids.offer_gasbase,
+      offer_gasbase: market.config().bids.offer_gasbase,
       tick: bidTick,
       gives: bidsGives,
       wants: bidTickHelper.inboundFromOutbound(bidTick, bidsGives),
@@ -1166,16 +1110,20 @@ describe("Market integration tests suite", () => {
       quote: "TokenB",
       tickSpacing: 1,
     });
-    await mgvAsAdmin.contract.setFee(
-      {
-        outbound_tkn: market.base.address,
-        inbound_tkn: market.quote.address,
-        tickSpacing: market.tickSpacing,
-      },
-      fee,
+    const tx = await waitForTransaction(
+      mgvAsAdmin.contract.setFee(
+        {
+          outbound_tkn: market.base.address,
+          inbound_tkn: market.quote.address,
+          tickSpacing: market.tickSpacing,
+        },
+        fee,
+      ),
     );
 
-    const config = await market.config();
+    await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+
+    const config = market.config();
     assert.strictEqual(config.asks.fee, fee, "wrong fee");
     mgvAsAdmin.disconnect();
   });
@@ -1414,7 +1362,7 @@ describe("Market integration tests suite", () => {
 
     // Add price/volume, prev/next, +extra info to expected book.
     // Volume always in base, price always in quote/base.
-    const config = await market.config();
+    const config = market.config();
     const complete = (isAsk: boolean, ary: typeof bids) => {
       return ary.map((ofr, i) => {
         const _config = config[isAsk ? "asks" : "bids"];

--- a/test/integration/offermaker.integration.test.ts
+++ b/test/integration/offermaker.integration.test.ts
@@ -191,7 +191,7 @@ describe("OfferMaker integration test suite", () => {
     } logic`, async () => {
       // Arrange
       const lp = eoaLP ? eoa_lp : onchain_lp;
-      const mgvGasprice = (await mgv.config()).gasprice;
+      const mgvGasprice = mgv.config().gasprice;
       const provision = await lp.computeAskProvision();
       const { id } = await lp.newAsk({
         tick: 10,
@@ -209,7 +209,7 @@ describe("OfferMaker integration test suite", () => {
       const expectedInitialProvision = mgv.calculateOfferProvision(
         mgvGasprice,
         lp.gasreq,
-        (await lp.market.getSemibook("asks").getConfig()).offer_gasbase,
+        lp.market.getSemibook("asks").config().offer_gasbase,
       );
       assert.equal(provision.toNumber(), expectedInitialProvision.toNumber());
       assert.equal(

--- a/test/unit/semibook.unit.test.ts
+++ b/test/unit/semibook.unit.test.ts
@@ -8,6 +8,7 @@ import UnitCalculations from "../../src/util/unitCalculations";
 import MangroveEventSubscriber from "../../src/mangroveEventSubscriber";
 import { expect } from "chai";
 import { TokenCalculations } from "../../src/token";
+import { Density } from "../../src/util/Density";
 describe("Semibook unit test suite", () => {
   describe("getIsVolumeDesiredForAsks", () => {
     it("returns false, when desiredVolume is undefined", async function () {
@@ -359,6 +360,12 @@ describe("Semibook unit test suite", () => {
 
     function createEmptyState(): Semibook.State {
       return {
+        localConfig: {
+          active: true,
+          fee: 0,
+          density: new Density(0, 0),
+          offer_gasbase: 1,
+        },
         offerCache: new Map(),
         binCache: new Map(),
         bestBinInCache: undefined,
@@ -1518,5 +1525,62 @@ describe("Semibook unit test suite", () => {
         });
       },
     );
+
+    describe(SemibookCacheOperations.prototype.setActive.name, () => {
+      [true, false].map((isActive) => {
+        it(`sets active to ${isActive}`, () => {
+          // Arrange
+          const state = createEmptyState();
+
+          // Act
+          cacheOperations.setActive(state, isActive);
+
+          // Assert
+          expect(state.localConfig.active).to.equal(isActive);
+        });
+      });
+    });
+
+    describe(SemibookCacheOperations.prototype.setFee.name, () => {
+      it("sets fee", () => {
+        // Arrange
+        const state = createEmptyState();
+        const fee = 10;
+
+        // Act
+        cacheOperations.setFee(state, fee);
+
+        // Assert
+        expect(state.localConfig.fee).to.equal(fee);
+      });
+    });
+
+    describe(SemibookCacheOperations.prototype.setGasbase.name, () => {
+      it("sets gasbase", () => {
+        // Arrange
+        const state = createEmptyState();
+        const gasbase = 10;
+
+        // Act
+        cacheOperations.setGasbase(state, gasbase);
+
+        // Assert
+        expect(state.localConfig.offer_gasbase).to.equal(gasbase);
+      });
+    });
+
+    describe(SemibookCacheOperations.prototype.setDensity.name, () => {
+      it("sets density", () => {
+        // Arrange
+        const state = createEmptyState();
+        const density = new Density(1, 2);
+
+        // Act
+        cacheOperations.setDensity(state, density);
+
+        // Assert
+        expect(state.localConfig.density).to.equal(density);
+      });
+    });
   });
 });


### PR DESCRIPTION
Mangrove and Semibook configs are now cached on `connect` and (for Semibook) updated by events.

The methods to read configs are no longer async and naming has been made consistent: `Mangrove.config()`, `Market.config()`, and `Semibook.config()`.

Caching the configs limits the RPC requests sent from frequently called methods, in particular `Semibook.simulateMarketOrder` which is used to eg estimate trading volumes and gas.

As part of this change, the following smaller changes have been made:
- Two missing global config fields have been added: `maxRecursionDepth` and `maxGasreqForFailingOffers`.
- All order book events now carry the relevant data for the event. And events that are not related to offers do not carry offer data.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205923576109048