### PR TITLE
feat: Implement MGV v2 simulateMarketOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - feat!: Mangrove and Semibook configs are now cached on 'connect' and (for Semibook) updated by events. The methods to read configs are no longer async and naming has been made consistent: 'Mangrove.config()', 'Market.config()', and 'Semibook.config()'.
 - feat: Two missing global config fields have been added: 'maxRecursionDepth' and 'maxGasreqForFailingOffers'.
 - feat!: All order book events now carry the relevant data for the event. And events that are not related to offers do not carry offer data.
+- feat: The market order simulation used to estimate volumes and gas has been updated to match Mangrove v2's market order logic.
+- feat!: 'Market.estimateVolume' now also estimates fees and returns it in a new 'estimatedFee' field. The existing 'estimatedVolume' field is exclusive of fees and thus represents the true amount the taker can expect to receive/pay.
 
 # 2.0.0-12
 

--- a/src/market.ts
+++ b/src/market.ts
@@ -344,6 +344,7 @@ namespace Market {
   export type VolumeEstimate = {
     maxTickMatched: number | undefined; // undefined iff no offers matched
     estimatedVolume: Big;
+    estimatedFee: Big;
     remainingFillVolume: Big;
   };
 }

--- a/src/semibook.ts
+++ b/src/semibook.ts
@@ -478,7 +478,7 @@ class Semibook
       ? this.tickPriceHelper.tickFromPrice(params.limitPrice)
       : MAX_TICK.toNumber();
 
-    const { totalGot, totalGave, feePaid, maxTickMatched } =
+    const { totalGot, totalGave, feePaid, fillVolume, maxTickMatched } =
       await this.simulateMarketOrder(maxTick, initialVolume, buying);
 
     const estimatedVolume = buying ? totalGave : totalGot;
@@ -486,7 +486,7 @@ class Semibook
     return {
       maxTickMatched,
       estimatedVolume: estimatedVolume,
-      remainingFillVolume: initialVolume.sub(estimatedVolume),
+      remainingFillVolume: fillVolume,
       estimatedFee: feePaid,
     };
   }
@@ -506,6 +506,7 @@ class Semibook
     totalGot: Big;
     totalGave: Big;
     feePaid: Big;
+    fillVolume: Big;
     maxTickMatched?: number;
     gas: BigNumber;
   }> {

--- a/src/semibook.ts
+++ b/src/semibook.ts
@@ -478,111 +478,185 @@ class Semibook
       ? this.tickPriceHelper.tickFromPrice(params.limitPrice)
       : MAX_TICK.toNumber();
 
-    const { maxTickMatched, remainingFillVolume, totalGot, totalGave } =
-      await this.simulateMarketOrder(maxTick, initialGives, buying);
+    const {
+      maxTickMatched,
+      remainingFillVolume,
+      totalGot,
+      totalGave,
+      feePaid,
+    } = await this.simulateMarketOrder(maxTick, initialGives, buying);
 
     const estimatedVolume = buying ? totalGave : totalGot;
 
-    return { maxTickMatched, estimatedVolume, remainingFillVolume };
+    return {
+      maxTickMatched,
+      estimatedVolume,
+      estimatedFee: feePaid,
+      remainingFillVolume,
+    };
   }
 
-  /* Reproduces the logic of MgvOfferTaking's internalMarketOrder & execute functions faithfully minus the overflow protections due to bounds on input sizes. */
+  /**
+   * Reproduces the logic of Mangrove's generalMarketOrder function faithfully
+   * with the exception of:
+   *
+   * - the overflow protections due to bounds on input sizes.
+   * - offers are assumed not to fail.
+   */
   async simulateMarketOrder(
     maxTick: number,
-    initialFillVolume: Big,
+    fillVolume: Big,
     fillWants: boolean,
   ): Promise<{
     maxTickMatched?: number;
     remainingFillVolume: Big;
     totalGot: Big;
     totalGave: Big;
+    feePaid: Big;
     gas: BigNumber;
   }> {
-    // reproduce solidity behavior
-    const previousBigRm = Big.RM;
-    Big.RM = Big.roundDown;
+    // require(fillVolume <= MAX_SAFE_VOLUME, "mgv/mOrder/fillVolume/tooBig");
+    // require(maxTick.inRange(), "mgv/mOrder/tick/outOfRange");
 
-    const initialAccumulator = {
-      stop: false,
-      maxTickMatched: undefined as number | undefined,
-      remainingFillVolume: initialFillVolume,
-      got: Big(0),
-      gave: Big(0),
+    const state = this.getLatestState();
+
+    const local = state.localConfig;
+    const global = this.market.mgv.config();
+
+    // This corresponds to the MultiOrder mor struct in generalMarketOrder.
+    let mor = {
       totalGot: Big(0),
       totalGave: Big(0),
+      // totalPenalty: Not used as offers are assumed not to fail
+      // taker: Not used
+      fillWants: fillWants,
+      fillVolume: fillVolume,
+      feePaid: Big(0),
+      // leaf: Not used
+      maxTick: maxTick,
+      // maxGasreqForFailingOffers: Not used as offers are assumed not to fail
+      // gasreqForFailingOffers: Not used as offers are assumed not to fail
+      maxRecursionDepth: global.maxRecursionDepth,
+
+      // Additional bookkeeping, not part of the original MultiOrder struct
+      stop: false,
+      maxTickMatched: undefined as number | undefined,
       offersConsidered: 0,
       totalGasreq: BigNumber.from(0),
       lastGasreq: 0,
     };
-    const state = this.getLatestState();
-    const res = await this.#foldLeftUntil(
+
+    // This corresponds to the SingleOrder sor struct in generalMarketOrder.
+    const sor = {
+      // olKey: implicit for this Semibook
+      // offerId: not used as full offer is available
+      // offer: provided by foldLeftUntil
+      takerWants: Big(0),
+      takerGives: Big(0),
+      // offerDetail: included in offer
+      global: global,
+      local: local,
+    };
+
+    mor = await this.#foldLeftUntil(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.lastSeenEventBlock!,
       state,
-      initialAccumulator,
-      (acc) => {
-        return !(!acc.stop && acc.remainingFillVolume.gt(0));
-      },
-      (offer, acc) => {
-        const fillVolume = acc.remainingFillVolume;
+      mor,
+      (acc) => acc.stop,
+      (offer, mor) => {
+        // This corresponds to the offer matching if-stmt in internalMarketOrder.
+        // Differences:
+        // 1/ In the Solidity code, 'offer' can be all zeros to signal the end of the offer list.
+        //    Here, foldLeftUntil will stop when there are no more offers, so zero offers need
+        //    not be handled explicitly.
+        // 2/ gasreqForFailingOffers is not taken into account here, since we assume offers do not fail.
+        if (
+          mor.fillVolume.gt(0) &&
+          offer.tick <= mor.maxTick && // && sor.offerId > 0
+          mor.maxRecursionDepth > 0 // && mor.gasreqForFailingOffers <= mor.maxGasreqForFailingOffers
+        ) {
+          // Extra bookkeeping, not part of the original internalMarketOrder function
+          mor.offersConsidered += 1;
+          mor.maxTickMatched = offer.tick;
+          mor.totalGasreq = mor.totalGasreq.add(offer.gasreq);
+          mor.lastGasreq = offer.gasreq;
 
-        acc.offersConsidered += 1;
+          mor.maxRecursionDepth--;
 
-        // bad price
-        if (offer.tick > maxTick) {
-          acc.stop = true;
-        } else {
-          acc.totalGasreq = acc.totalGasreq.add(offer.gasreq);
-          acc.lastGasreq = offer.gasreq;
-          const offerWants = this.tickPriceHelper.inboundFromOutbound(
-            offer.tick,
-            offer.gives,
-          );
+          // function execute
+          const fillVolume = mor.fillVolume;
+          const offerGives = offer.gives;
+          const offerWants = offer.wants;
+
           if (
-            (fillWants && fillVolume.gt(offer.gives)) ||
-            (!fillWants && fillVolume.gt(offerWants))
+            (mor.fillWants && offerGives.lte(fillVolume)) ||
+            (!mor.fillWants && offerWants.lte(fillVolume))
           ) {
-            acc.got = offer.gives;
-            acc.gave = offerWants;
+            sor.takerWants = offerGives;
+            sor.takerGives = offerWants;
           } else {
-            if (fillWants) {
-              acc.got = fillVolume;
-              const product = fillVolume.mul(offerWants);
-              /* Reproduce the mangrove round-up of takerGives using Big's rounding mode. */
-              Big.RM = Big.roundUp;
-              acc.gave = product.div(offer.gives);
-              Big.RM = Big.roundDown;
+            if (mor.fillWants) {
+              sor.takerGives = this.tickPriceHelper.inboundFromOutbound(
+                offer.tick,
+                fillVolume,
+                true,
+              );
+              sor.takerWants = fillVolume;
             } else {
-              acc.gave = fillVolume;
-              if (offerWants.eq(0)) {
-                acc.got = offer.gives;
-              } else {
-                acc.got = fillVolume.mul(offer.gives).div(offerWants);
-              }
+              sor.takerWants = this.tickPriceHelper.outboundFromInbound(
+                offer.tick,
+                fillVolume,
+                false,
+              );
+              sor.takerGives = fillVolume;
             }
           }
-        }
-        if (!acc.stop) {
-          acc.maxTickMatched = offer.tick;
-          acc.totalGot = acc.totalGot.add(acc.got);
-          acc.totalGave = acc.totalGave.add(acc.gave);
-          acc.remainingFillVolume = initialFillVolume.sub(
-            fillWants ? acc.totalGot : acc.totalGave,
+
+          mor.totalGot = mor.totalGot.add(sor.takerWants);
+          // require(mor.totalGot >= sor.takerWants, "mgv/totalGot/overflow");
+          mor.totalGave = mor.totalGave.add(sor.takerGives);
+          // require(mor.totalGave >= sor.takerGives, "mgv/totalGave/overflow");
+          // end function execute
+
+          const takerWants = sor.takerWants;
+          const takerGives = sor.takerGives;
+          mor.fillVolume = mor.fillVolume.sub(
+            mor.fillWants ? takerWants : takerGives,
           );
+        } else {
+          mor.stop = true;
+
+          // payTakerMinusFees is called here in the Solidity code
+          // but foldLeftUntil may stop before this if we reach the end of the offer list.
+          // Therefore the payTakerMinusFees logic is moved to after foldLeftUntil.
         }
-        return acc;
+
+        return mor;
       },
     );
 
+    // function payTakerMinusFees
+    // Reproduce Solidity rounding behavior
+    const previousBigRm = Big.RM;
+    const previousBigDp = Big.DP;
+    Big.RM = Big.roundDown;
+    Big.DP = this.market.getOutboundInbound(this.ba).outbound_tkn.decimals;
+    const concreteFee = mor.totalGot.mul(sor.local.fee).div(10_000);
+    Big.DP = previousBigDp;
     Big.RM = previousBigRm;
+    if (concreteFee.gt(0)) {
+      mor.totalGot = mor.totalGot.sub(concreteFee);
+      mor.feePaid = concreteFee;
+    }
+    // end function payTakerMinusFees
 
-    // Assume up to offer_gasbase is used also for the bad price call, and
-    // the last offer (which could be first, if taking little) needs up to gasreq*64/63 for makerPosthook
-    const gas = res.totalGasreq
-      .add(BigNumber.from(res.lastGasreq).div(63))
-      .add(state.localConfig.offer_gasbase * Math.max(res.offersConsidered, 1));
+    // Assumes offer_gasbase is used also for the last call to internalMarketOrder where no offer is executed.
+    const gas = mor.totalGasreq.add(
+      local.offer_gasbase * (mor.offersConsidered + 1),
+    );
 
-    return { ...res, gas };
+    return { ...mor, gas, remainingFillVolume: mor.fillVolume };
   }
 
   /** Returns `true` if `price` is better than `referencePrice`; Otherwise, `false` is returned.
@@ -1135,6 +1209,12 @@ class Semibook
       );
     } else if ("desiredVolume" in options) {
       const desiredVolume = options.desiredVolume;
+      if (Big(desiredVolume.given).eq(0)) {
+        return {
+          error: undefined,
+          ok: { bins: new Map(), endOfListReached: false },
+        };
+      }
       const getOfferVolume = (offer: Market.Offer) => {
         if (desiredVolume.to === "buy") {
           return offer.gives;
@@ -1159,6 +1239,12 @@ class Semibook
       );
     } else {
       const targetNumberOfTicks = options.targetNumberOfTicks;
+      if (targetNumberOfTicks === 0) {
+        return {
+          error: undefined,
+          ok: { bins: new Map(), endOfListReached: false },
+        };
+      }
       return await this.#fetchOfferListPrefixUntil(
         block,
         fromId,

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -1177,29 +1177,35 @@ describe("Market integration tests suite", () => {
         tickSpacing: 1,
       });
 
-      const done = new Deferred();
-      let volumeEstimate: Market.VolumeEstimate | undefined;
-      const baseVolume = 0.5;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      market.subscribe(async (evt) => {
-        if (market.getBook().asks.size() === 2) {
-          volumeEstimate = await market.estimateVolume({
-            given: baseVolume,
-            what: "base",
-            to: "buy",
-          });
-          done.resolve();
-        }
-      });
-
       const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
-      await helpers
-        .newOffer({ mgv, market, ba: "asks", gives: "0.3", price })
-        .then((tx) => tx.wait());
-      await helpers
-        .newOffer({ mgv, market, ba: "asks", gives: "0.25", price })
-        .then((tx) => tx.wait());
-      await done.promise;
+
+      await waitForTransaction(
+        await helpers.newOffer({
+          mgv,
+          market,
+          ba: "asks",
+          gives: "0.3",
+          price,
+        }),
+      );
+      const tx = await waitForTransaction(
+        await helpers.newOffer({
+          mgv,
+          market,
+          ba: "asks",
+          gives: "0.25",
+          price,
+        }),
+      );
+
+      await waitForBlock(mgv, tx.blockNumber);
+
+      const baseVolume = 0.5;
+      const volumeEstimate = await market.estimateVolume({
+        given: baseVolume,
+        what: "base",
+        to: "buy",
+      });
 
       // estimated volume is in quote = inbound token and the fee is taken in base = outbound token
       const expectedEstimatedVolume = price.mul(baseVolume).toNumber();
@@ -1241,29 +1247,34 @@ describe("Market integration tests suite", () => {
         tickSpacing: 1,
       });
 
-      const done = new Deferred();
-      let volumeEstimate: Market.VolumeEstimate | undefined;
-      const quoteVolume = 2;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      market.subscribe(async (evt) => {
-        if (market.getBook().asks.size() === 2) {
-          volumeEstimate = await market.estimateVolume({
-            given: quoteVolume,
-            what: "quote",
-            to: "sell",
-          });
-          done.resolve();
-        }
-      });
-
       const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
-      await helpers
-        .newOffer({ mgv, market, ba: "asks", gives: "0.3", price })
-        .then((tx) => tx.wait());
-      await helpers
-        .newOffer({ mgv, market, ba: "asks", gives: "0.25", price })
-        .then((tx) => tx.wait());
-      await done.promise;
+      await waitForTransaction(
+        await helpers.newOffer({
+          mgv,
+          market,
+          ba: "asks",
+          gives: "0.3",
+          price,
+        }),
+      );
+      const tx = await waitForTransaction(
+        await helpers.newOffer({
+          mgv,
+          market,
+          ba: "asks",
+          gives: "0.25",
+          price,
+        }),
+      );
+
+      await waitForBlock(mgv, tx.blockNumber);
+
+      const quoteVolume = 2;
+      const volumeEstimate = await market.estimateVolume({
+        given: quoteVolume,
+        what: "quote",
+        to: "sell",
+      });
 
       // estimated volume is in base = outbound token and the fee is taken in base
       const expectedEstimatedVolumeIncludingFee = Big(2).div(price).toNumber();

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -7,7 +7,9 @@ import * as mgvTestUtil from "../../src/util/test/mgvIntegrationTestUtil";
 import {
   rawMinGivesBase,
   rawMinGivesQuote,
+  waitForBlock,
   waitForTransaction,
+  waitForTransactions,
 } from "../../src/util/test/mgvIntegrationTestUtil";
 
 import assert from "assert";
@@ -589,36 +591,7 @@ describe("Market integration tests suite", () => {
       const volumeEstimate: Market.VolumeEstimate = {
         maxTickMatched: 0,
         estimatedVolume: new Big(12),
-        remainingFillVolume: new Big(12),
-      };
-      mockito
-        .when(mockedMarket.estimateVolume(mockito.anything()))
-        .thenResolve(volumeEstimate);
-
-      // Act
-      const result = await market.estimateVolumeToReceive(params);
-      const paramsUsed = mockito.capture(mockedMarket.estimateVolume).last();
-
-      // Assert
-      expect(paramsUsed[0].to).to.be.eq("sell");
-      expect(result).to.be.eq(volumeEstimate);
-    });
-
-    it("return estimate value for sell", async function () {
-      // Arrange
-      const market = await mgv.market({
-        base: "TokenB",
-        quote: "TokenA",
-        tickSpacing: 1,
-      });
-      const mockedMarket = mockito.spy(market);
-      const params: Market.DirectionlessVolumeParams = {
-        what: "quote",
-        given: "",
-      };
-      const volumeEstimate: Market.VolumeEstimate = {
-        maxTickMatched: 0,
-        estimatedVolume: new Big(12),
+        estimatedFee: new Big(1),
         remainingFillVolume: new Big(12),
       };
       mockito
@@ -649,6 +622,7 @@ describe("Market integration tests suite", () => {
       const volumeEstimate: Market.VolumeEstimate = {
         maxTickMatched: 0,
         estimatedVolume: new Big(12),
+        estimatedFee: new Big(1),
         remainingFillVolume: new Big(12),
       };
       mockito
@@ -841,7 +815,7 @@ describe("Market integration tests suite", () => {
     const tx = await mgvTestUtil.postNewFailingOffer(market, "asks", maker);
 
     // make sure the offer tx has been gen'ed and the OfferWrite has been logged
-    await mgvTestUtil.waitForBlock(market.mgv, tx.blockNumber);
+    await waitForBlock(market.mgv, tx.blockNumber);
 
     const events = [await queue.get()];
     expect(events).to.have.lengthOf(1);
@@ -872,7 +846,7 @@ describe("Market integration tests suite", () => {
     await mgvTestUtil.mint(market.quote, maker, 100);
     await mgvTestUtil.mint(market.base, maker, 100);
     const tx2 = await mgvTestUtil.postNewSucceedingOffer(market, "asks", maker);
-    await mgvTestUtil.waitForBlock(mgv, tx2.blockNumber);
+    await waitForBlock(mgv, tx2.blockNumber);
     const buyPromises_ = await market.buy({
       maxTick: 1,
       fillVolume: "1.5e12",
@@ -1008,7 +982,7 @@ describe("Market integration tests suite", () => {
       gives: rawMinGivesQuote,
     });
 
-    await mgvTestUtil.waitForBlock(market.mgv, tx.blockNumber);
+    await waitForBlock(market.mgv, tx.blockNumber);
 
     const sellPromises = await market.sell({
       fillVolume: "0.0001",
@@ -1099,33 +1073,26 @@ describe("Market integration tests suite", () => {
   });
 
   it("gets config", async function () {
-    const mgvAsAdmin = await Mangrove.connect({
-      provider: this.server.url,
-      privateKey: this.accounts.deployer.key,
-    });
-
-    const fee = 13;
     const market = await mgv.market({
       base: "TokenA",
       quote: "TokenB",
       tickSpacing: 1,
     });
-    const tx = await waitForTransaction(
-      mgvAsAdmin.contract.setFee(
-        {
-          outbound_tkn: market.base.address,
-          inbound_tkn: market.quote.address,
-          tickSpacing: market.tickSpacing,
-        },
-        fee,
-      ),
-    );
 
-    await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+    const fee = 13;
+    const txs = await waitForTransactions(
+      helpers.setFee({
+        mgvAdmin,
+        base: "TokenA",
+        quote: "TokenB",
+        tickSpacing: 1,
+        fee,
+      }),
+    );
+    await waitForBlock(mgv, txs[txs.length - 1].blockNumber);
 
     const config = market.config();
     assert.strictEqual(config.asks.fee, fee, "wrong fee");
-    mgvAsAdmin.disconnect();
   });
 
   it("updates OB", async function () {
@@ -1188,39 +1155,137 @@ describe("Market integration tests suite", () => {
     //TODO add to after
   });
 
-  it("crudely simulates market buy", async function () {
-    const market = await mgv.market({
-      base: "TokenA",
-      quote: "TokenB",
-      tickSpacing: 1,
+  [0, 123].map((fee) => {
+    it(`crudely simulates market buy, fee = ${fee} bps ~ ${
+      fee / 100
+    }%`, async function () {
+      const txs = await waitForTransactions(
+        helpers.setFee({
+          mgvAdmin,
+          base: "TokenA",
+          quote: "TokenB",
+          tickSpacing: 1,
+          fee,
+        }),
+      );
+
+      await waitForBlock(mgv, txs[txs.length - 1].blockNumber);
+
+      const market = await mgv.market({
+        base: "TokenA",
+        quote: "TokenB",
+        tickSpacing: 1,
+      });
+
+      const done = new Deferred();
+      let volumeEstimate: Market.VolumeEstimate | undefined;
+      const baseVolume = 0.5;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      market.subscribe(async (evt) => {
+        if (market.getBook().asks.size() === 2) {
+          volumeEstimate = await market.estimateVolume({
+            given: baseVolume,
+            what: "base",
+            to: "buy",
+          });
+          done.resolve();
+        }
+      });
+
+      const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
+      await helpers
+        .newOffer({ mgv, market, ba: "asks", gives: "0.3", price })
+        .then((tx) => tx.wait());
+      await helpers
+        .newOffer({ mgv, market, ba: "asks", gives: "0.25", price })
+        .then((tx) => tx.wait());
+      await done.promise;
+
+      // estimated volume is in quote = inbound token and the fee is taken in base = outbound token
+      const expectedEstimatedVolume = price.mul(baseVolume).toNumber();
+      const expectedEstimatedFee = (baseVolume * fee) / 10_000;
+
+      const estimatedVolume = volumeEstimate!.estimatedVolume.toNumber();
+      expect(estimatedVolume).to.be.approximately(
+        expectedEstimatedVolume,
+        0.0001,
+        "estimatedVolume is incorrect",
+      );
+
+      const estimatedFee = volumeEstimate!.estimatedFee.toNumber();
+      expect(estimatedFee).to.be.approximately(
+        expectedEstimatedFee,
+        0.0001,
+        "estimatedFee is incorrect",
+      );
     });
 
-    const done = new Deferred();
-    let estimatedVolume = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    market.subscribe(async (evt) => {
-      if (market.getBook().asks.size() === 2) {
-        const { estimatedVolume: estimated } = await market.estimateVolume({
-          given: "2",
-          what: "quote",
-          to: "sell",
-        });
-        estimatedVolume = estimated.toNumber();
-        done.resolve();
-      }
-    });
+    it(`crudely simulates market sell, fee = ${fee} bps ~ ${
+      fee / 100
+    }%`, async function () {
+      const txs = await waitForTransactions(
+        helpers.setFee({
+          mgvAdmin,
+          base: "TokenA",
+          quote: "TokenB",
+          tickSpacing: 1,
+          fee,
+        }),
+      );
 
-    await helpers
-      .newOffer({ mgv, market, ba: "asks", gives: "0.3", price: 4 })
-      .then((tx) => tx.wait());
-    await helpers
-      .newOffer({ mgv, market, ba: "asks", gives: "0.25", price: 4 })
-      .then((tx) => tx.wait());
-    await done.promise;
-    assert.ok(
-      Math.abs(estimatedVolume! - 0.5) < 0.0001,
-      `estimatedVolume should be ~0.5, got ${estimatedVolume}`,
-    );
+      await waitForBlock(mgv, txs[txs.length - 1].blockNumber);
+
+      const market = await mgv.market({
+        base: "TokenA",
+        quote: "TokenB",
+        tickSpacing: 1,
+      });
+
+      const done = new Deferred();
+      let volumeEstimate: Market.VolumeEstimate | undefined;
+      const quoteVolume = 2;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      market.subscribe(async (evt) => {
+        if (market.getBook().asks.size() === 2) {
+          volumeEstimate = await market.estimateVolume({
+            given: quoteVolume,
+            what: "quote",
+            to: "sell",
+          });
+          done.resolve();
+        }
+      });
+
+      const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
+      await helpers
+        .newOffer({ mgv, market, ba: "asks", gives: "0.3", price })
+        .then((tx) => tx.wait());
+      await helpers
+        .newOffer({ mgv, market, ba: "asks", gives: "0.25", price })
+        .then((tx) => tx.wait());
+      await done.promise;
+
+      // estimated volume is in base = outbound token and the fee is taken in base
+      const expectedEstimatedVolumeIncludingFee = Big(2).div(price).toNumber();
+      const expectedEstimatedFee =
+        (expectedEstimatedVolumeIncludingFee * fee) / 10_000;
+      const expectedEstimatedVolume =
+        expectedEstimatedVolumeIncludingFee - expectedEstimatedFee;
+
+      const estimatedVolume = volumeEstimate!.estimatedVolume.toNumber();
+      expect(estimatedVolume).to.be.approximately(
+        expectedEstimatedVolume,
+        0.0001,
+        "estimatedVolume is incorrect",
+      );
+
+      const estimatedFee = volumeEstimate!.estimatedFee.toNumber();
+      expect(estimatedFee).to.be.approximately(
+        expectedEstimatedFee,
+        0.0001,
+        "estimatedFee is incorrect",
+      );
+    });
   });
 
   it("gets OB", async function () {
@@ -1459,7 +1524,7 @@ describe("Market integration tests suite", () => {
       newOffer({ mgv, market, ba: "asks", ...asks[0] }),
     );
 
-    await mgvTestUtil.waitForBlock(market.mgv, lastTx.blockNumber);
+    await waitForBlock(market.mgv, lastTx.blockNumber);
     const asksEstimate = await market.gasEstimateBuy({
       volume: market.base.fromUnits(1),
       limitPrice: 1,

--- a/test/integration/semibook.integration.test.ts
+++ b/test/integration/semibook.integration.test.ts
@@ -4,16 +4,23 @@ import { expect } from "chai";
 import { afterEach, beforeEach, describe, it } from "mocha";
 
 import * as mgvTestUtil from "../../src/util/test/mgvIntegrationTestUtil";
-import { assertApproxEqAbs, newOffer, toWei } from "../util/helpers";
+import {
+  assertApproxEqAbs,
+  createTickPriceHelper,
+  newOffer,
+  toWei,
+} from "../util/helpers";
 const waitForTransaction = mgvTestUtil.waitForTransaction;
 
-import { Mangrove, Semibook } from "../../src";
+import { Mangrove, Market, Semibook, TickPriceHelper } from "../../src";
 
 import { TransactionReceipt } from "@ethersproject/providers";
 import { Big } from "big.js";
 import { BigNumber } from "ethers";
 import { Density } from "../../src/util/Density";
 import * as DensityLib from "../../src/util/coreCalculations/DensityLib";
+import { Bigish } from "../../src/types";
+import { waitForBlock } from "../../src/util/test/mgvIntegrationTestUtil";
 
 //pretty-print when using console.log
 Big.prototype[Symbol.for("nodejs.util.inspect.custom")] = function () {
@@ -64,7 +71,7 @@ describe("Semibook integration tests suite", function () {
         }),
       );
 
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       const market = await mgv.market({
         base: "TokenA",
@@ -89,7 +96,7 @@ describe("Semibook integration tests suite", function () {
           tick: 1,
         }),
       );
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       const market = await mgv.market({
         base: "TokenA",
@@ -153,7 +160,7 @@ describe("Semibook integration tests suite", function () {
         ),
       );
 
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       const config = semibook.config();
 
@@ -162,7 +169,7 @@ describe("Semibook integration tests suite", function () {
         newDensity,
         market.base.decimals,
       );
-      expect(config.density.eq(newDensityFrom96X32)).to.be.eq(
+      expect(config.density.eq(newDensityFrom96X32)).to.equal(
         true,
         `Expected ${config.density.toString()} to be equal to ${newDensityFrom96X32.toString()}`,
       );
@@ -189,7 +196,7 @@ describe("Semibook integration tests suite", function () {
         }),
       );
 
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       const bestInCache = market.getSemibook("asks").getBestInCache();
       expect(bestInCache).to.be.eq(1);
@@ -207,7 +214,7 @@ describe("Semibook integration tests suite", function () {
           tick: 1,
         }),
       );
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       const market = await mgv.market({
         base: "TokenA",
@@ -221,630 +228,615 @@ describe("Semibook integration tests suite", function () {
   });
 
   describe("estimateVolume", () => {
+    let askTickPriceHelper: TickPriceHelper;
+
+    beforeEach(async function () {
+      askTickPriceHelper = await createTickPriceHelper({
+        mgv,
+        ba: "asks",
+        base: "TokenA",
+        quote: "TokenB",
+        tickSpacing: 1,
+      });
+    });
+
+    function getExpectedEstimates(params: {
+      given: Bigish;
+      to: "buy" | "sell";
+      price: Bigish;
+      fee: number;
+      expectedRemainingFillVolume: Bigish;
+    }) {
+      const given = Big(params.given);
+      const expectedRemainingFillVolume = Big(
+        params.expectedRemainingFillVolume,
+      );
+      const price = Big(params.price);
+      const fee = params.fee;
+
+      if (params.to === "buy") {
+        const baseVolume = given.sub(expectedRemainingFillVolume);
+        const quoteVolume = baseVolume.mul(price);
+        return {
+          expectedFee: baseVolume.mul(fee).div(10_000),
+          expectedVolume: quoteVolume,
+        };
+      } else {
+        const quoteVolume = given.sub(expectedRemainingFillVolume);
+        const baseVolume = quoteVolume.div(price);
+        const expectedFee = baseVolume.mul(fee).div(10_000);
+        return {
+          expectedFee,
+          expectedVolume: quoteVolume.div(price).sub(expectedFee),
+        };
+      }
+    }
+
+    function assertApproxEq(params: {
+      volumeEstimate: Market.VolumeEstimate;
+      expectedVolume: Bigish;
+      expectedFee: Bigish;
+      expectedRemainingFillVolume: Bigish;
+      maxTickMatched?: number;
+    }) {
+      assertApproxEqAbs(
+        params.volumeEstimate.estimatedVolume,
+        params.expectedVolume,
+        0.001,
+        "estimatedVolume is wrong",
+      );
+      assertApproxEqAbs(
+        params.volumeEstimate.remainingFillVolume,
+        params.expectedRemainingFillVolume,
+        0.001,
+        "remainingFillVolume is wrong",
+      );
+      assertApproxEqAbs(
+        params.volumeEstimate.estimatedFee,
+        params.expectedFee,
+        0.001,
+        "expectedFee is wrong",
+      );
+      assert.equal(
+        params.volumeEstimate.maxTickMatched,
+        params.maxTickMatched,
+        "maxTickMatched is wrong",
+      );
+    }
+
     (["buy", "sell"] as const).forEach((to) =>
-      describe(`estimateVolume({to: ${to}}) - cache tests`, () => {
-        it("returns all given as residue when cache and offer list is empty", async function () {
-          const market = await mgv.market({
-            base: "TokenA",
-            quote: "TokenB",
-            tickSpacing: 1,
+      describe(`estimateVolume({to: ${to}})`, () => {
+        describe("cache tests", () => {
+          it("returns all given as residue when cache and offer list is empty", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+              bookOptions: { targetNumberOfTicks: 0 },
+            });
+            const semibook = market.getSemibook("asks");
+            const volume = await semibook.estimateVolume({ given: 1, to });
+            expect(volume).to.deep.equal({
+              maxTickMatched: undefined,
+              estimatedVolume: Big(0),
+              estimatedFee: Big(0),
+              remainingFillVolume: Big(1),
+            });
           });
-          const semibook = market.getSemibook("asks");
-          const volume = await semibook.estimateVolume({ given: 1, to });
-          expect(volume).to.deep.equal({
-            maxTickMatched: undefined,
-            estimatedVolume: Big(0),
-            remainingFillVolume: Big(1),
+
+          it("returns correct estimate and residue when cache is empty and offer list is not", async function () {
+            const tick = askTickPriceHelper.tickFromPrice(1);
+
+            // Post 2 asks
+            let tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick,
+              }),
+            );
+            tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            // Connect to market but do not load offers
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+              bookOptions: { targetNumberOfTicks: 0, chunkSize: 1 },
+            });
+            const semibook = market.getSemibook("asks");
+            expect(semibook.size()).to.equal(0);
+
+            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const given = 1;
+
+            const expectedRemainingFillVolume = 0;
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volume = await semibook.estimateVolume({ given, to });
+
+            assertApproxEqAbs(
+              volume.estimatedVolume,
+              expectedVolume,
+              0.001,
+              "estimatedVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.remainingFillVolume,
+              expectedRemainingFillVolume,
+              0.001,
+              "remainingFillVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.estimatedFee,
+              expectedFee,
+              0.001,
+              "expectedFee is wrong",
+            );
+          });
+
+          it("returns correct estimate and residue when cache is partial and insufficient while offer list is sufficient", async function () {
+            const tick = askTickPriceHelper.tickFromPrice(1);
+            // Post 2 asks at different ticks
+            let tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick,
+              }),
+            );
+            tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick: tick + 1,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            // Connect to market but only load 1 offer
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+              bookOptions: { targetNumberOfTicks: 1, chunkSize: 1 },
+            });
+            const semibook = market.getSemibook("asks");
+            expect(semibook.size()).to.equal(1);
+
+            // Price difference between the two ticks is negligible
+            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const given = 2;
+
+            const expectedRemainingFillVolume = 0;
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volume = await semibook.estimateVolume({ given, to });
+
+            assertApproxEqAbs(
+              volume.estimatedVolume,
+              expectedVolume,
+              0.001,
+              "estimatedVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.remainingFillVolume,
+              expectedRemainingFillVolume,
+              0.001,
+              "remainingFillVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.estimatedFee,
+              expectedFee,
+              0.001,
+              "expectedFee is wrong",
+            );
+          });
+
+          it("returns correct estimate and residue when cache is partial and offer list is insufficient", async function () {
+            const tick = askTickPriceHelper.tickFromPrice(1);
+            // Post 2 asks at different ticks
+            let tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick,
+              }),
+            );
+            tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick: tick + 1,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            // Connect to market but only load 1 offer
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+              bookOptions: { targetNumberOfTicks: 1, chunkSize: 1 },
+            });
+            const semibook = market.getSemibook("asks");
+            expect(semibook.size()).to.equal(1);
+
+            // Price difference between the two ticks is negligible
+            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const given = 3;
+
+            const expectedRemainingFillVolume = 1;
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volume = await semibook.estimateVolume({ given, to });
+
+            assertApproxEqAbs(
+              volume.estimatedVolume,
+              expectedVolume,
+              0.001,
+              "estimatedVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.remainingFillVolume,
+              expectedRemainingFillVolume,
+              0.001,
+              "remainingFillVolume is wrong",
+            );
+            assertApproxEqAbs(
+              volume.estimatedFee,
+              expectedFee,
+              0.001,
+              "expectedFee is wrong",
+            );
           });
         });
 
-        it("returns correct estimate and residue when cache is empty and offer list is not", async function () {
-          const market = await mgv.market({
-            base: "TokenA",
-            quote: "TokenB",
-            tickSpacing: 1,
-            bookOptions: { targetNumberOfTicks: 0 },
+        describe("calculation tests", () => {
+          it("returns zero when given is zero", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+            });
+            const semibook = market.getSemibook("asks");
+
+            const tick = semibook.tickPriceHelper.tickFromPrice(2);
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: "1",
+                tick,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            const volumeEstimate = await semibook.estimateVolume({
+              given: 0,
+              to,
+            });
+
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume: 0,
+              expectedFee: 0,
+              expectedRemainingFillVolume: 0,
+              maxTickMatched: undefined,
+            });
           });
-          const semibook = market.getSemibook("asks");
 
-          const tick = semibook.tickPriceHelper.tickFromVolumes(1, 1);
+          it("reversed market: returns zero when given is zero", async function () {
+            const market = await mgv.market({
+              base: "TokenB",
+              quote: "TokenA",
+              tickSpacing: 1,
+            });
+            const semibook = market.getSemibook("asks");
 
-          // Put one offer on asks
-          const tx = await waitForTransaction(
-            newOffer({
-              mgv,
-              outbound: "TokenA",
-              inbound: "TokenB",
-              gives: "1",
-              tick: tick,
-            }),
-          );
+            const tick = semibook.tickPriceHelper.tickFromPrice(2);
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenB",
+                inbound: "TokenA",
+                gives: "1",
+                tick,
+              }),
+            );
 
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+            await waitForBlock(mgv, tx.blockNumber);
 
-          const volume = await semibook.estimateVolume({ given: 1, to });
+            const volumeEstimate = await semibook.estimateVolume({
+              given: 0,
+              to,
+            });
 
-          assertApproxEqAbs(
-            volume.estimatedVolume,
-            1,
-            0.001,
-            "estimatedVolume should be 1",
-          );
-          assertApproxEqAbs(
-            volume.remainingFillVolume,
-            0,
-            0.001,
-            "remainingFillVolume should be 0",
-          );
-        });
-
-        it("returns correct estimate and residue when cache is partial and insufficient while offer list is sufficient", async function () {
-          // Load 1 offer in cache
-          const market = await mgv.market({
-            base: "TokenA",
-            quote: "TokenB",
-            tickSpacing: 1,
-            bookOptions: { targetNumberOfTicks: 1 },
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume: 0,
+              expectedFee: 0,
+              expectedRemainingFillVolume: 0,
+              maxTickMatched: undefined,
+            });
           });
-          const semibook = market.getSemibook("asks");
 
-          const tick = semibook.tickPriceHelper.tickFromVolumes(1, 1);
+          it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+            });
 
-          const ask1 = await (
-            await newOffer({
-              mgv,
-              outbound: "TokenA",
-              inbound: "TokenB",
-              gives: "1",
-              tick: tick,
-            })
-          ).wait();
+            const semibook = market.getSemibook("asks");
 
-          // Put one offer on asks
-          await mgvTestUtil.waitForBlock(mgv, ask1.blockNumber);
+            const offerPrice = 2;
+            const offerGives = 1;
+            const offerTick =
+              semibook.tickPriceHelper.tickFromPrice(offerPrice);
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offerGives,
+                tick: offerTick,
+              }),
+            );
 
-          const ask2 = await (
-            await newOffer({
-              mgv,
-              outbound: "TokenA",
-              inbound: "TokenB",
-              gives: "2",
-              tick: tick,
-            })
-          ).wait();
+            await waitForBlock(mgv, tx.blockNumber);
 
-          await mgvTestUtil.waitForBlock(mgv, ask2.blockNumber);
+            const expectedRemainingFillVolume = 1;
 
-          const volume = await semibook.estimateVolume({ given: 2, to });
+            const price = semibook.tickPriceHelper.priceFromTick(offerTick);
+            const given =
+              (to === "buy" ? offerGives : offerGives * offerPrice) +
+              expectedRemainingFillVolume;
 
-          assertApproxEqAbs(
-            volume.estimatedVolume,
-            2,
-            0.001,
-            "estimatedVolume should be 2",
-          );
-          assertApproxEqAbs(
-            volume.remainingFillVolume,
-            0,
-            0.001,
-            "remainingFillVolume should be 0",
-          );
-        });
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
 
-        it("returns correct estimate and residue when cache is partial and offer list is insufficient", async function () {
-          const market = await mgv.market({
-            base: "TokenA",
-            quote: "TokenB",
-            tickSpacing: 1,
-            bookOptions: { targetNumberOfTicks: 1 },
+            const volumeEstimate = await semibook.estimateVolume({ given, to });
+
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume,
+              expectedFee,
+              expectedRemainingFillVolume,
+              maxTickMatched: offerTick,
+            });
           });
-          const semibook = market.getSemibook("asks");
 
-          const tick = semibook.tickPriceHelper.tickFromVolumes(1, 1);
-          // Put two offers on asks
-          const offer1 = await (
-            await newOffer({
-              mgv,
-              outbound: "TokenA",
-              inbound: "TokenB",
-              gives: "1",
-              tick,
-            })
-          ).wait();
+          it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+            });
+            const semibook = market.getSemibook("asks");
 
-          await mgvTestUtil.waitForBlock(mgv, offer1.blockNumber);
+            const offer1Price = 2;
+            const offer1Gives = 1;
+            const offer1Tick =
+              semibook.tickPriceHelper.tickFromPrice(offer1Price);
+            await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offer1Gives,
+                tick: offer1Tick,
+              }),
+            );
+            const offer2Price = 2;
+            const offer2Gives = 1;
+            const offer2Tick =
+              semibook.tickPriceHelper.tickFromPrice(offer2Price);
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offer2Gives,
+                tick: offer2Tick,
+              }),
+            );
 
-          const offer2 = await (
-            await newOffer({
-              mgv,
-              outbound: "TokenA",
-              inbound: "TokenB",
-              gives: "1",
-              tick,
-            })
-          ).wait();
+            await waitForBlock(mgv, tx.blockNumber);
 
-          await mgvTestUtil.waitForBlock(mgv, offer2.blockNumber);
+            const expectedRemainingFillVolume = 1;
 
-          const volume = await semibook.estimateVolume({ given: 3, to });
+            // Total price will be the average of the offers since they give the same amounts
+            const price = semibook.tickPriceHelper
+              .priceFromTick(offer1Tick)
+              .add(semibook.tickPriceHelper.priceFromTick(offer2Tick))
+              .div(2);
+            const given =
+              (to === "buy"
+                ? offer1Gives + offer2Gives
+                : offer1Gives * offer1Price + offer2Gives * offer2Price) +
+              expectedRemainingFillVolume;
 
-          assertApproxEqAbs(
-            volume.estimatedVolume,
-            2,
-            0.001,
-            "estimatedVolume should be 2",
-          );
-          assertApproxEqAbs(
-            volume.remainingFillVolume,
-            1,
-            0.001,
-            "remainingFillVolume should be 1",
-          );
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volumeEstimate = await semibook.estimateVolume({ given, to });
+
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume,
+              expectedFee,
+              expectedRemainingFillVolume,
+              maxTickMatched: offer2Tick,
+            });
+          });
+
+          it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+            });
+            const semibook = market.getSemibook("asks");
+
+            const offerPrice = 2;
+            const offerGives = 2;
+            const offerTick =
+              semibook.tickPriceHelper.tickFromPrice(offerPrice);
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offerGives,
+                tick: offerTick,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            const expectedRemainingFillVolume = 0;
+
+            const price = semibook.tickPriceHelper.priceFromTick(offerTick);
+            const given =
+              (to === "buy" ? offerGives : offerGives * offerPrice) - 1;
+
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volumeEstimate = await semibook.estimateVolume({ given, to });
+
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume,
+              expectedFee,
+              expectedRemainingFillVolume,
+              maxTickMatched: offerTick,
+            });
+          });
+
+          it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
+            const market = await mgv.market({
+              base: "TokenA",
+              quote: "TokenB",
+              tickSpacing: 1,
+            });
+
+            const semibook = market.getSemibook("asks");
+
+            const offersPrice = 2;
+            const offer1Gives = 1;
+            const offersTick =
+              semibook.tickPriceHelper.tickFromPrice(offersPrice);
+            await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offer1Gives,
+                tick: offersTick,
+              }),
+            );
+            const offer2Gives = 2;
+            const tx = await waitForTransaction(
+              newOffer({
+                mgv,
+                outbound: "TokenA",
+                inbound: "TokenB",
+                gives: offer2Gives,
+                tick: offersTick,
+              }),
+            );
+
+            await waitForBlock(mgv, tx.blockNumber);
+
+            const expectedRemainingFillVolume = 0;
+
+            // Both offers have same price
+            const price = semibook.tickPriceHelper.priceFromTick(offersTick);
+            const given =
+              (to === "buy"
+                ? offer1Gives + offer2Gives
+                : offer1Gives * offersPrice + offer2Gives * offersPrice) - 1;
+
+            const { expectedVolume, expectedFee } = getExpectedEstimates({
+              given,
+              to,
+              price,
+              fee: semibook.config().fee,
+              expectedRemainingFillVolume,
+            });
+
+            const volumeEstimate = await semibook.estimateVolume({ given, to });
+
+            assertApproxEq({
+              volumeEstimate,
+              expectedVolume,
+              expectedFee,
+              expectedRemainingFillVolume,
+              maxTickMatched: offersTick,
+            });
+          });
         });
       }),
     );
-
-    describe("estimateVolume({to: buy}) - calculation tests", () => {
-      it("returns zero when given is zero", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick,
-          }),
-        );
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 0, to: "buy" });
-        assert.deepStrictEqual(
-          volume.estimatedVolume.toFixed(),
-          "0",
-          "estimatedVolume should be 0",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-
-      it("reversed market: returns zero when given is zero", async function () {
-        const market = await mgv.market({
-          base: "TokenB",
-          quote: "TokenA",
-          tickSpacing: 1,
-        });
-        const semibook = market.getSemibook("asks");
-        const tick = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenB",
-            inbound: "TokenA",
-            gives: "1",
-            tick: tick,
-          }),
-        );
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-        const volume = await semibook.estimateVolume({ given: 0, to: "buy" });
-
-        assert.deepStrictEqual(
-          volume.estimatedVolume.toFixed(),
-          "0",
-          "estimatedVolume should be 0",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-
-      it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-        const tick = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 2, to: "buy" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick.toString(),
-          `tick should be ${tick.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(2).abs().lt(0.001),
-          true,
-          `estimatedVolume should be 2, but is ${volume.estimatedVolume.toFixed()}`,
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "1",
-          "remainingFillVolume should be 1",
-        );
-      });
-
-      it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick1 = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick1,
-          }),
-        );
-
-        const tick2 = semibook.tickPriceHelper.tickFromVolumes(3, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick2,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-        const volume = await semibook.estimateVolume({ given: 3, to: "buy" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick2.toString(),
-          `tick should be ${tick2.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(5).abs().lt(0.001),
-          true,
-          `estimatedVolume should be 5, but is ${volume.estimatedVolume.toFixed()}`,
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "1",
-          "remainingFillVolume should be 1",
-        );
-      });
-
-      it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick = semibook.tickPriceHelper.tickFromVolumes(4, 2);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "2",
-            tick,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 1, to: "buy" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick.toString(),
-          `tick should be ${tick.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(2).abs().lt(0.001),
-          true,
-          `estimatedVolume should be 2, but is ${volume.estimatedVolume.toFixed()}`,
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-
-      it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick1 = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick1,
-          }),
-        );
-        const tick2 = semibook.tickPriceHelper.tickFromVolumes(4, 2);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "2",
-            tick: tick2,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 2, to: "buy" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick2.toString(),
-          `tick should be ${tick2.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(4).abs().lt(0.001),
-          true,
-          "estimatedVolume should be 4",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-    });
-
-    describe("estimateVolume({to: sell}) - calculation tests", () => {
-      it("returns zero when given is zero", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-        const semibook = market.getSemibook("asks");
-
-        const tick = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-        const volume = await semibook.estimateVolume({ given: 0, to: "sell" });
-
-        assert.deepStrictEqual(
-          volume.estimatedVolume.toFixed(),
-          "0",
-          `estimatedVolume should be 0, but is ${volume.estimatedVolume.toFixed()}`,
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          `remainingFillVolume should be 0, but is ${volume.remainingFillVolume.toFixed()}`,
-        );
-      });
-
-      it("estimates all available volume when offer list has 1 offer with insufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-        const volume = await semibook.estimateVolume({ given: 3, to: "sell" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick.toString(),
-          `tick should be ${tick.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.toFixed(),
-          "1",
-          "estimatedVolume should be 1",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.sub(1).abs().lt(0.001),
-          true,
-          "remainingFillVolume should be 1",
-        );
-      });
-
-      it("estimates all available volume when offer list has multiple offers with insufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-        const semibook = market.getSemibook("asks");
-
-        const tick1 = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick1,
-          }),
-        );
-        const tick2 = semibook.tickPriceHelper.tickFromVolumes(3, 1);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick2,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 6, to: "sell" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick2.toString(),
-          `tick should be ${tick2.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.toFixed(),
-          "2",
-          "estimatedVolume should be 2",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.sub(1).abs().lt(0.001),
-          true,
-          `remainingFillVolume should be 1, but is ${volume.remainingFillVolume.toFixed()}`,
-        );
-      });
-
-      it("estimates volume and no residue when offer list has 1 offer with sufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-        const semibook = market.getSemibook("asks");
-
-        const tick = semibook.tickPriceHelper.tickFromVolumes(4, 2);
-
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "2",
-            tick,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 2, to: "sell" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick.toString(),
-          `tick should be ${tick.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(1).abs().lt(0.001),
-          true,
-          "estimatedVolume should be 1",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-
-      it("estimates volume and no residue when offer list has multiple offers which together have sufficient volume", async function () {
-        const market = await mgv.market({
-          base: "TokenA",
-          quote: "TokenB",
-          tickSpacing: 1,
-        });
-
-        const semibook = market.getSemibook("asks");
-
-        const tick1 = semibook.tickPriceHelper.tickFromVolumes(2, 1);
-        await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "1",
-            tick: tick1,
-          }),
-        );
-        const tick2 = semibook.tickPriceHelper.tickFromVolumes(4, 2);
-        const tx = await waitForTransaction(
-          newOffer({
-            mgv,
-            outbound: "TokenA",
-            inbound: "TokenB",
-            gives: "2",
-            tick: tick2,
-          }),
-        );
-
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
-
-        const volume = await semibook.estimateVolume({ given: 3, to: "sell" });
-        assert.deepStrictEqual(
-          volume.maxTickMatched?.toString(),
-          tick2.toString(),
-          `tick should be ${tick2.toString()}`,
-        );
-        assert.deepStrictEqual(
-          volume.estimatedVolume.sub(1.5).abs().lt(0.001),
-          true,
-          "estimatedVolume should be 1.5",
-        );
-        assert.deepStrictEqual(
-          volume.remainingFillVolume.toFixed(),
-          "0",
-          "remainingFillVolume should be 0",
-        );
-      });
-    });
   });
 
   describe("initialization options", () => {
@@ -860,7 +852,7 @@ describe("Semibook integration tests suite", function () {
           }),
         );
 
-        await mgvTestUtil.waitForBlock(mgv, tx!.blockNumber);
+        await waitForBlock(mgv, tx!.blockNumber);
       }
       async function createOffers(count: number) {
         if (count < 1) {
@@ -1036,7 +1028,7 @@ describe("Semibook integration tests suite", function () {
             tick: 2,
           }),
         );
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+        await waitForBlock(mgv, tx.blockNumber);
 
         const market = await mgv.market({
           base: "TokenA",
@@ -1071,7 +1063,7 @@ describe("Semibook integration tests suite", function () {
           }),
         );
 
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+        await waitForBlock(mgv, tx.blockNumber);
 
         const market = await mgv.market({
           base: "TokenA",
@@ -1123,7 +1115,7 @@ describe("Semibook integration tests suite", function () {
             tick: 4,
           }),
         );
-        await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+        await waitForBlock(mgv, tx.blockNumber);
 
         const market = await mgv.market({
           base: "TokenA",
@@ -1198,7 +1190,7 @@ describe("Semibook integration tests suite", function () {
               tick: tick2,
             }),
           );
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+          await waitForBlock(mgv, tx.blockNumber);
 
           expect(semibook.size()).to.equal(2);
         });
@@ -1230,7 +1222,7 @@ describe("Semibook integration tests suite", function () {
               tick: tick1,
             })
           ).wait();
-          await mgvTestUtil.waitForBlock(mgv, offer1.blockNumber);
+          await waitForBlock(mgv, offer1.blockNumber);
 
           const tick2 = semibook.tickPriceHelper.tickFromPrice(1.002);
           await newOffer({
@@ -1281,7 +1273,7 @@ describe("Semibook integration tests suite", function () {
               tick: 4,
             }),
           );
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+          await waitForBlock(mgv, tx.blockNumber);
 
           const market = await mgv.market({
             base: "TokenA",
@@ -1347,7 +1339,7 @@ describe("Semibook integration tests suite", function () {
               tick,
             }),
           );
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+          await waitForBlock(mgv, tx.blockNumber);
 
           const newMgv = await Mangrove.connect({
             provider: mgv.provider,
@@ -1390,7 +1382,7 @@ describe("Semibook integration tests suite", function () {
               tick: 1,
             }),
           );
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+          await waitForBlock(mgv, tx.blockNumber);
 
           const newMgv = await Mangrove.connect({
             provider: mgv.provider,
@@ -1472,7 +1464,7 @@ describe("Semibook integration tests suite", function () {
               tick: tick1,
             }),
           );
-          await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+          await waitForBlock(mgv, tx.blockNumber);
 
           const newMgv = await Mangrove.connect({
             provider: mgv.provider,
@@ -1544,7 +1536,7 @@ describe("Semibook integration tests suite", function () {
       );
       const semibook = market.getSemibook("asks");
 
-      await mgvTestUtil.waitForBlock(mgv, tx.blockNumber);
+      await waitForBlock(mgv, tx.blockNumber);
 
       // Act
       const minVolume = semibook.getMinimumVolume(0);
@@ -1642,7 +1634,7 @@ describe("Semibook integration tests suite", function () {
 
       // wait for offer(s) to be recorded in OB
       if (lastTx) {
-        await mgvTestUtil.waitForBlock(mgv, lastTx.blockNumber);
+        await waitForBlock(mgv, lastTx.blockNumber);
       }
 
       const actualAsksMaxGasReq = await market.getBook().asks.getMaxGasReq();


### PR DESCRIPTION
The market order simulation used to estimate volumes and gas has been updated to match Mangrove v2's market order logic.

As part of this, `Market.estimateVolume` now also estimates fees and returns it in a new `estimatedFee` field. The existing `estimatedVolume` field is exclusive of fees and thus represents the true amount the taker can expect to receive/pay.
