### PR TITLE
feat(tickSpacing): Round up, down, or to nearest depending on scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- feat: Round up, down, or to nearest depending on scenario
+- fix!: Rename getRequiredOutboundForGas to getRequiredOutboundForGasreq
 - Add Sepolia support by bumping the following packages:
   - @mangrovedao/mangrove-core to v2.0.3
   - @mangrovedao/mangrove-strats to v1.0.2

--- a/examples/tutorials/deploy-kandel.js
+++ b/examples/tutorials/deploy-kandel.js
@@ -7,7 +7,6 @@ const {
   KandelStrategies,
   ethers,
 } = require("@mangrovedao/mangrove.js");
-const { addressesConfiguration } = require("@mangrovedao/mangrove.js");
 
 // Create a wallet with a provider to interact with the chain
 const provider = new ethers.providers.WebSocketProvider(process.env.LOCAL_URL);
@@ -28,15 +27,6 @@ const kandelStrategies = new KandelStrategies(mgv);
 
 // Retrieve default configuration for the selected market
 const config = kandelStrategies.configuration.getConfig(market);
-
-//FIXME: add KandelLib manually until address packages are updated
-const kandelLibAddress = (await kandelStrategies.farm.getKandels())[0]
-  .kandelAddress;
-addressesConfiguration.setAddress(
-  "KandelLib",
-  kandelLibAddress,
-  wallet.provider.network.name,
-);
 
 // Create a distribution generator for the selected market
 const distributionGenerator = kandelStrategies.generator(market);

--- a/src/kandel/geometricKandel/geometricKandelStatus.ts
+++ b/src/kandel/geometricKandel/geometricKandelStatus.ts
@@ -133,9 +133,11 @@ class GeometricKandelStatus {
     stepSize: number,
     offers: { bids: OffersWithLiveness; asks: OffersWithLiveness },
   ): Statuses {
+    // Round to nearest as that seems fair to both sides
     const midBaseQuoteTick =
       this.geometricDistributionHelper.helper.askTickPriceHelper.tickFromPrice(
         midPrice,
+        "nearest",
       );
 
     // We select an offer close to mid to since those are the first to be populated, so higher chance of being correct than offers further out.
@@ -176,9 +178,11 @@ class GeometricKandelStatus {
         expectedLiveBid: baseQuoteTick <= midBaseQuoteTick,
         expectedLiveAsk: baseQuoteTick >= midBaseQuoteTick,
         expectedBaseQuoteTick: baseQuoteTick,
+        // tick already respects tick spacing so rounding has no effect
         expectedPrice:
           this.geometricDistributionHelper.helper.askTickPriceHelper.priceFromTick(
             baseQuoteTick,
+            "roundUp",
           ),
         asks: undefined as
           | undefined
@@ -194,10 +198,11 @@ class GeometricKandelStatus {
       statuses[index][offerType] = {
         live,
         id,
+        // tick already respects tick spacing so rounding has no effect
         price: (offerType == "asks"
           ? this.geometricDistributionHelper.helper.askTickPriceHelper
           : this.geometricDistributionHelper.helper.bidTickPriceHelper
-        ).priceFromTick(tick),
+        ).priceFromTick(tick, "roundUp"),
         tick,
       };
     });
@@ -248,13 +253,16 @@ class GeometricKandelStatus {
         index: offer.index,
         id: offer.id,
       },
+      // ticks already respects tick spacing so rounding has no effect - if it had an effect then the inverse rounding of the inverse operation seems appropriate
       minPrice:
         this.geometricDistributionHelper.helper.askTickPriceHelper.priceFromTick(
           minBaseQuoteTick,
+          "roundDown",
         ),
       maxPrice:
         this.geometricDistributionHelper.helper.askTickPriceHelper.priceFromTick(
           maxBaseQuoteTick,
+          "roundUp",
         ),
       minBaseQuoteTick,
       maxBaseQuoteTick,

--- a/src/kandel/kandelDistribution.ts
+++ b/src/kandel/kandelDistribution.ts
@@ -127,7 +127,9 @@ class KandelDistribution {
         ...x,
         price: this.helper[
           ba === "bids" ? "bidTickPriceHelper" : "askTickPriceHelper"
-        ].priceFromTick(x.tick),
+        ]
+          // Rounding does not matter since tick should already be binned
+          .priceFromTick(x.tick, "roundUp"),
       }),
     );
   }

--- a/src/kandel/kandelDistributionHelper.ts
+++ b/src/kandel/kandelDistributionHelper.ts
@@ -157,7 +157,7 @@ class KandelDistributionHelper {
       const minimumBaseFromQuote = this.bidTickPriceHelper.inboundFromOutbound(
         maxBidTick,
         minimumQuotePerOffer,
-        true,
+        "roundUp",
       );
       askGives = minimumBaseFromQuote.gt(minimumBasePerOffer)
         ? minimumBaseFromQuote
@@ -168,7 +168,7 @@ class KandelDistributionHelper {
       const minimumQuoteFromBase = this.askTickPriceHelper.inboundFromOutbound(
         maxAskTick,
         minimumBasePerOffer,
-        true,
+        "roundUp",
       );
       bidGives = minimumQuoteFromBase.gt(minimumQuotePerOffer)
         ? minimumQuoteFromBase

--- a/src/market.ts
+++ b/src/market.ts
@@ -570,10 +570,10 @@ class Market {
     const gasreq = configuration.mangroveOrder.getRestingOrderGasreq(
       market.mgv.network.name,
     );
-    market.minVolumeAsk = config.asks.density.getRequiredOutboundForGas(
+    market.minVolumeAsk = config.asks.density.getRequiredOutboundForGasreq(
       config.asks.offer_gasbase + gasreq,
     );
-    market.minVolumeBid = config.bids.density.getRequiredOutboundForGas(
+    market.minVolumeBid = config.bids.density.getRequiredOutboundForGasreq(
       config.bids.offer_gasbase + gasreq,
     );
     return market;

--- a/src/util/Density.ts
+++ b/src/util/Density.ts
@@ -112,12 +112,15 @@ export class Density {
   /**
    * Get the minimum amount of outbound tokens required for the given amount of gas.
    *
-   * @param gas the amount of gas to calculate the required outbound for
+   * @param gasreq the amount of gas to calculate the required outbound for
    * @returns the minimum amount of outbound tokens required for the given amount of gas
    */
-  getRequiredOutboundForGas(gas: BigNumberish): Big {
+  getRequiredOutboundForGasreq(gasreq: BigNumberish): Big {
     return Big(
-      DensityLib.multiplyUp(this.#rawDensity, BigNumber.from(gas)).toString(),
+      DensityLib.multiplyUp(
+        this.#rawDensity,
+        BigNumber.from(gasreq),
+      ).toString(),
     ).div(Big(10).pow(this.#outboundDecimals));
   }
 

--- a/src/util/tickPriceHelper.ts
+++ b/src/util/tickPriceHelper.ts
@@ -6,7 +6,7 @@ import Big from "big.js";
 import { Bigish } from "../types";
 import { MANTISSA_BITS, MIN_RATIO_EXP } from "./coreCalculations/Constants";
 
-/** roundDown rounds toward zero. roundUp rounds away from zero, and nearest tries to round to the nearest being towards or away from zero. Default is nearest. */
+/** roundDown rounds toward zero. roundUp rounds away from zero, and nearest tries to round to the nearest being towards or away from zero. */
 export type RoundingMode = "nearest" | "roundDown" | "roundUp";
 
 class TickPriceHelper {
@@ -44,18 +44,15 @@ class TickPriceHelper {
   /**
    * Calculates the price at a given raw offer list tick.
    * @param tick tick to calculate price for (is coerced to nearest bin)
-   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest. Up is to a higher price, down is to a lower price.
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. See {@link RoundingMode}. Up is to a higher price, down is to a lower price.
    * @returns price at tick (not to be confused with offer list ratio).
    */
-  priceFromTick(tick: number, roundingMode?: RoundingMode): Big {
+  priceFromTick(tick: number, roundingMode: RoundingMode): Big {
     // Increase decimals due to pow and division potentially needing more than the default 20.
     const dp = Big.DP;
     Big.DP = 300;
 
-    const offerListRatioFromTick = this.rawRatioFromTick(
-      tick,
-      roundingMode ?? "nearest",
-    );
+    const offerListRatioFromTick = this.rawRatioFromTick(tick, roundingMode);
     // For scaling the price to the correct decimals since the ratio is for raw values.
     const decimalsScaling = Big(10).pow(
       this.market.base.decimals - this.market.quote.decimals,
@@ -75,10 +72,10 @@ class TickPriceHelper {
   /**
    * Calculates the raw offer list tick (coerced to nearest bin) at a given order book price (not to be confused with offer list ratio).
    * @param price price to calculate tick for
-   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
+   * @param roundingMode See {@link RoundingMode} Lower is to a lower tick, higher is to a higher tick.
    * @returns raw offer list tick (coerced to nearest bin) for price
    */
-  tickFromPrice(price: Bigish, roundingMode?: RoundingMode): number {
+  tickFromPrice(price: Bigish, roundingMode: RoundingMode): number {
     // Increase decimals due to pow and division potentially needing more than the default 20.
     const dp = Big.DP;
     Big.DP = 300;
@@ -95,10 +92,7 @@ class TickPriceHelper {
         : priceAdjustedForDecimals;
 
     // TickLib.getTickFromPrice expects a ratio of rawInbound/rawOutbound, which is now available in offerListRatio
-    const tick = this.tickFromRawRatio(
-      offerListRatio,
-      roundingMode ?? "nearest",
-    );
+    const tick = this.tickFromRawRatio(offerListRatio, roundingMode);
     Big.DP = dp;
     return tick;
   }
@@ -106,7 +100,7 @@ class TickPriceHelper {
   /**
    * Coerces a price to a representable price on a tick. Note that due to rounding, coercing a coerced price may yield a price on an adjacent tick.
    * @param price price to coerce
-   * @param roundingMode @see RoundingMode, default is nearest.
+   * @param roundingMode See {@link RoundingMode}
    * @returns the price coerced to nearest representable tick */
   coercePrice(price: Bigish, roundingMode: RoundingMode): Big {
     let tick = this.tickFromPrice(price, roundingMode);
@@ -129,7 +123,7 @@ class TickPriceHelper {
    * Calculates the inbound amount from an outbound amount at a given tick.
    * @param tick tick to calculate the amount for (coerced to nearest bin)
    * @param outboundAmount amount to calculate the inbound amount for
-   * @param roundingMode @see RoundingMode, default is nearest.
+   * @param roundingMode See {@link RoundingMode}.
    * @returns inbound amount.
    */
   inboundFromOutbound(
@@ -154,7 +148,7 @@ class TickPriceHelper {
    * Calculates the outbound amount from an inbound amount at a given tick.
    * @param tick tick to calculate the amount for (coerced to nearest bin)
    * @param inboundAmount amount to calculate the outbound amount for
-   * @param roundingMode @see RoundingMode, default is nearest.
+   * @param roundingMode See {@link RoundingMode}
    * @returns inbound amount.
    */
   outboundFromInbound(
@@ -189,7 +183,7 @@ class TickPriceHelper {
    * Calculates the tick (coerced to nearest bin) from inbound and outbound volumes.
    * @param inboundVolume inbound amount to calculate the tick for
    * @param outboundVolume outbound amount to calculate the tick for
-   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
+   * @param roundingMode See {@link RoundingMode}. Lower is to a lower tick, higher is to a higher tick.
    * @returns raw offer list tick (coerced to nearest bin) for volumes
    */
   tickFromVolumes(
@@ -232,7 +226,7 @@ class TickPriceHelper {
 
   /** Coerce a tick to its nearest bin
    * @param tick tick to coerce
-   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
+   * @param roundingMode See {@link RoundingMode}. Lower is to a lower tick, higher is to a higher tick.
    * @return tick coerced to its nearest bin
    */
   public coerceTick(tick: number, roundingMode: RoundingMode): number {
@@ -254,7 +248,7 @@ class TickPriceHelper {
 
   /** Coerce a tick to its nearest bin
    * @param tick tick to coerce
-   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. See {@link RoundingMode}
    * @returns tick coerced to its nearest bin
    */
   private nearestRepresentableTick(
@@ -295,7 +289,7 @@ class TickPriceHelper {
    * NB: Raw ratios do not take token decimals into account.
    *
    * @param tick tick to calculate the ratio for (coerced to nearest bin)
-   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. See {@link RoundingMode}
    * @returns ratio as a Big.
    */
   public rawRatioFromTick(tick: number, roundingMode: RoundingMode): Big {
@@ -319,7 +313,7 @@ class TickPriceHelper {
    * NB: This is a lossy conversions since ticks are discrete and ratios are not.
    *
    * @param rawRatio inbound/outbound ratio to calculate the tick for
-   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. See {@link RoundingMode}
    * @returns a tick (coerced to nearest bin) that approximates the given ratio.
    */
   public tickFromRawRatio(rawRatio: Big, roundingMode: RoundingMode): number {

--- a/src/util/tickPriceHelper.ts
+++ b/src/util/tickPriceHelper.ts
@@ -6,6 +6,9 @@ import Big from "big.js";
 import { Bigish } from "../types";
 import { MANTISSA_BITS, MIN_RATIO_EXP } from "./coreCalculations/Constants";
 
+/** roundDown rounds toward zero. roundUp rounds away from zero, and nearest tries to round to the nearest being towards or away from zero. Default is nearest. */
+export type RoundingMode = "nearest" | "roundDown" | "roundUp";
+
 class TickPriceHelper {
   readonly ba: Market.BA;
   readonly market: Market.KeyResolvedForCalculation;
@@ -41,14 +44,18 @@ class TickPriceHelper {
   /**
    * Calculates the price at a given raw offer list tick.
    * @param tick tick to calculate price for (is coerced to nearest bin)
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest. Up is to a higher price, down is to a lower price.
    * @returns price at tick (not to be confused with offer list ratio).
    */
-  priceFromTick(tick: number): Big {
+  priceFromTick(tick: number, roundingMode?: RoundingMode): Big {
     // Increase decimals due to pow and division potentially needing more than the default 20.
     const dp = Big.DP;
     Big.DP = 300;
 
-    const offerListRatioFromTick = this.rawRatioFromTick(tick);
+    const offerListRatioFromTick = this.rawRatioFromTick(
+      tick,
+      roundingMode ?? "nearest",
+    );
     // For scaling the price to the correct decimals since the ratio is for raw values.
     const decimalsScaling = Big(10).pow(
       this.market.base.decimals - this.market.quote.decimals,
@@ -68,10 +75,10 @@ class TickPriceHelper {
   /**
    * Calculates the raw offer list tick (coerced to nearest bin) at a given order book price (not to be confused with offer list ratio).
    * @param price price to calculate tick for
+   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
    * @returns raw offer list tick (coerced to nearest bin) for price
    */
-  // TODO: Consider allowing the user to control whether to round up or down.
-  tickFromPrice(price: Bigish): number {
+  tickFromPrice(price: Bigish, roundingMode?: RoundingMode): number {
     // Increase decimals due to pow and division potentially needing more than the default 20.
     const dp = Big.DP;
     Big.DP = 300;
@@ -79,7 +86,6 @@ class TickPriceHelper {
     const decimalsScaling = Big(10).pow(
       this.market.base.decimals - this.market.quote.decimals,
     );
-
     const priceAdjustedForDecimals = Big(price).div(decimalsScaling);
 
     // Since ratio is for inbound/outbound, and price is quote/base, they coincide (modulo scaling) for asks, and we inverse the price to get ratio for bids
@@ -89,7 +95,10 @@ class TickPriceHelper {
         : priceAdjustedForDecimals;
 
     // TickLib.getTickFromPrice expects a ratio of rawInbound/rawOutbound, which is now available in offerListRatio
-    const tick = this.tickFromRawRatio(offerListRatio);
+    const tick = this.tickFromRawRatio(
+      offerListRatio,
+      roundingMode ?? "nearest",
+    );
     Big.DP = dp;
     return tick;
   }
@@ -97,25 +106,47 @@ class TickPriceHelper {
   /**
    * Coerces a price to a representable price on a tick. Note that due to rounding, coercing a coerced price may yield a price on an adjacent tick.
    * @param price price to coerce
+   * @param roundingMode @see RoundingMode, default is nearest.
    * @returns the price coerced to nearest representable tick */
-  coercePrice(price: Bigish): Big {
-    const tick = this.tickFromPrice(price);
-    return this.priceFromTick(tick);
+  coercePrice(price: Bigish, roundingMode: RoundingMode): Big {
+    let tick = this.tickFromPrice(price, roundingMode);
+    let coercedPrice = this.priceFromTick(tick, roundingMode);
+    if (roundingMode === "roundDown") {
+      while (coercedPrice.gt(price)) {
+        tick -= this.market.tickSpacing;
+        coercedPrice = this.priceFromTick(tick, roundingMode);
+      }
+    } else if (roundingMode === "roundUp") {
+      while (coercedPrice.lt(price)) {
+        tick += this.market.tickSpacing;
+        coercedPrice = this.priceFromTick(tick, roundingMode);
+      }
+    }
+    return coercedPrice;
   }
 
   /**
    * Calculates the inbound amount from an outbound amount at a given tick.
    * @param tick tick to calculate the amount for (coerced to nearest bin)
    * @param outboundAmount amount to calculate the inbound amount for
-   * @param roundUp whether to round up (true) or down (falsy)
+   * @param roundingMode @see RoundingMode, default is nearest.
    * @returns inbound amount.
    */
-  inboundFromOutbound(tick: number, outboundAmount: Bigish, roundUp?: boolean) {
-    const bin = this.nearestRepresentableTick(BigNumber.from(tick));
+  inboundFromOutbound(
+    tick: number,
+    outboundAmount: Bigish,
+    roundingMode: RoundingMode,
+  ) {
+    const binnedTick = this.nearestRepresentableTick(
+      BigNumber.from(tick),
+      roundingMode,
+    );
     const rawOutbound = this.#getOutbound().toUnits(outboundAmount);
     const rawInbound = (
-      roundUp ? TickLib.inboundFromOutboundUp : TickLib.inboundFromOutbound
-    )(bin, rawOutbound);
+      roundingMode === "roundUp"
+        ? TickLib.inboundFromOutboundUp
+        : TickLib.inboundFromOutbound
+    )(binnedTick, rawOutbound);
     return this.#getInbound().fromUnits(rawInbound);
   }
 
@@ -123,15 +154,24 @@ class TickPriceHelper {
    * Calculates the outbound amount from an inbound amount at a given tick.
    * @param tick tick to calculate the amount for (coerced to nearest bin)
    * @param inboundAmount amount to calculate the outbound amount for
-   * @param roundUp whether to round up (true) or down (falsy)
+   * @param roundingMode @see RoundingMode, default is nearest.
    * @returns inbound amount.
    */
-  outboundFromInbound(tick: number, inboundAmount: Bigish, roundUp?: boolean) {
-    const bin = this.nearestRepresentableTick(BigNumber.from(tick));
+  outboundFromInbound(
+    tick: number,
+    inboundAmount: Bigish,
+    roundingMode: RoundingMode,
+  ) {
+    const binnedTick = this.nearestRepresentableTick(
+      BigNumber.from(tick),
+      roundingMode,
+    );
     const rawInbound = this.#getInbound().toUnits(inboundAmount);
     const rawOutbound = (
-      roundUp ? TickLib.outboundFromInboundUp : TickLib.outboundFromInbound
-    )(bin, rawInbound);
+      roundingMode === "roundUp"
+        ? TickLib.outboundFromInboundUp
+        : TickLib.outboundFromInbound
+    )(binnedTick, rawInbound);
     return this.#getOutbound().fromUnits(rawOutbound);
   }
 
@@ -149,14 +189,42 @@ class TickPriceHelper {
    * Calculates the tick (coerced to nearest bin) from inbound and outbound volumes.
    * @param inboundVolume inbound amount to calculate the tick for
    * @param outboundVolume outbound amount to calculate the tick for
+   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
    * @returns raw offer list tick (coerced to nearest bin) for volumes
    */
-  tickFromVolumes(inboundVolume: Bigish, outboundVolume: Bigish): number {
+  tickFromVolumes(
+    inboundVolume: Bigish,
+    outboundVolume: Bigish,
+    roundingMode: RoundingMode,
+  ): number {
     const rawInbound = this.#getInbound().toUnits(inboundVolume);
     const rawOutbound = this.#getOutbound().toUnits(outboundVolume);
     const tick = TickLib.tickFromVolumes(rawInbound, rawOutbound);
-    const bin = this.nearestRepresentableTick(tick);
-    return bin.toNumber();
+    let binnedTick = this.nearestRepresentableTick(
+      tick,
+      roundingMode,
+    ).toNumber();
+
+    // Since the `tick` can be off, the `binnedTick` can be off, so we correct it.
+    if (roundingMode === "roundDown") {
+      while (
+        this.inboundFromOutbound(binnedTick, outboundVolume, roundingMode).gt(
+          inboundVolume,
+        )
+      ) {
+        binnedTick -= this.market.tickSpacing;
+      }
+    } else if (roundingMode === "roundUp") {
+      while (
+        this.inboundFromOutbound(binnedTick, outboundVolume, roundingMode).lt(
+          inboundVolume,
+        )
+      ) {
+        binnedTick += this.market.tickSpacing;
+      }
+    }
+
+    return binnedTick;
   }
 
   // Helper functions for converting between ticks and ratios as Big instead of the special format used by TickLib.
@@ -164,10 +232,14 @@ class TickPriceHelper {
 
   /** Coerce a tick to its nearest bin
    * @param tick tick to coerce
+   * @param roundingMode @see RoundingMode, default is nearest. Lower is to a lower tick, higher is to a higher tick.
    * @return tick coerced to its nearest bin
    */
-  public coerceTick(tick: number): number {
-    return this.nearestRepresentableTick(BigNumber.from(tick)).toNumber();
+  public coerceTick(tick: number, roundingMode: RoundingMode): number {
+    return this.nearestRepresentableTick(
+      BigNumber.from(tick),
+      roundingMode,
+    ).toNumber();
   }
 
   /** Check if tick is exact, as in it does not change when coerced due to tick spacing
@@ -175,18 +247,46 @@ class TickPriceHelper {
    * @returns true if tick is exact; otherwise, false
    */
   public isTickExact(tick: number): boolean {
-    return this.nearestRepresentableTick(BigNumber.from(tick)).eq(tick);
+    return this.nearestRepresentableTick(BigNumber.from(tick), "roundDown").eq(
+      tick,
+    );
   }
 
   /** Coerce a tick to its nearest bin
    * @param tick tick to coerce
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
    * @returns tick coerced to its nearest bin
    */
-  private nearestRepresentableTick(tick: BigNumber): BigNumber {
-    return TickLib.nearestBin(
+  private nearestRepresentableTick(
+    tick: BigNumber,
+    roundingMode: RoundingMode,
+  ): BigNumber {
+    // Note: nearestBin is a misnomer - it rounds
+    let binnedTick = TickLib.nearestBin(
       tick,
       BigNumber.from(this.market.tickSpacing),
     ).mul(this.market.tickSpacing);
+
+    if (!binnedTick.eq(tick)) {
+      if (roundingMode === "roundDown") {
+        while (binnedTick.gt(tick)) {
+          binnedTick = binnedTick.sub(this.market.tickSpacing);
+        }
+      } else if (roundingMode === "roundUp") {
+        // Since nearestBin rounds up, this has no effect.
+        while (binnedTick.lt(tick)) {
+          binnedTick = binnedTick.add(this.market.tickSpacing);
+        }
+      } else {
+        const diff = binnedTick.sub(tick).toNumber();
+        if (diff < 0 && diff < -this.market.tickSpacing / 2) {
+          binnedTick = binnedTick.add(this.market.tickSpacing);
+        } else if (diff > 0 && diff > this.market.tickSpacing / 2) {
+          binnedTick = binnedTick.sub(this.market.tickSpacing);
+        }
+      }
+    }
+    return binnedTick;
   }
 
   /**
@@ -195,11 +295,15 @@ class TickPriceHelper {
    * NB: Raw ratios do not take token decimals into account.
    *
    * @param tick tick to calculate the ratio for (coerced to nearest bin)
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
    * @returns ratio as a Big.
    */
-  public rawRatioFromTick(tick: number): Big {
-    const bin = this.nearestRepresentableTick(BigNumber.from(tick));
-    const { man, exp } = TickLib.ratioFromTick(bin);
+  public rawRatioFromTick(tick: number, roundingMode: RoundingMode): Big {
+    const binnedTick = this.nearestRepresentableTick(
+      BigNumber.from(tick),
+      roundingMode,
+    );
+    const { man, exp } = TickLib.ratioFromTick(binnedTick);
     // Increase decimals due to pow and division potentially needing more than the default 20.
     const dp = Big.DP;
     Big.DP = 300;
@@ -214,14 +318,29 @@ class TickPriceHelper {
    * NB: Raw ratios do not take token decimals into account.
    * NB: This is a lossy conversions since ticks are discrete and ratios are not.
    *
-   * @param ratio ratio to calculate the tick for
+   * @param rawRatio inbound/outbound ratio to calculate the tick for
+   * @param roundingMode the rounding mode for coercing tick to a representable tick. @see RoundingMode, default is nearest.
    * @returns a tick (coerced to nearest bin) that approximates the given ratio.
    */
-  public tickFromRawRatio(ratio: Big): number {
-    const { man, exp } = TickPriceHelper.rawRatioToMantissaExponent(ratio);
+  public tickFromRawRatio(rawRatio: Big, roundingMode: RoundingMode): number {
+    const { man, exp } = TickPriceHelper.rawRatioToMantissaExponent(rawRatio);
     const tick = TickLib.tickFromRatio(man, exp);
-    const bin = this.nearestRepresentableTick(tick);
-    return bin.toNumber();
+    let binnedTick = this.nearestRepresentableTick(tick, roundingMode);
+    // Since the `tick` can be off, the `binnedTick` can be off, so we correct it.
+    if (roundingMode === "roundDown") {
+      while (
+        this.rawRatioFromTick(binnedTick.toNumber(), roundingMode).gt(rawRatio)
+      ) {
+        binnedTick = binnedTick.sub(this.market.tickSpacing);
+      }
+    } else if (roundingMode === "roundUp") {
+      while (
+        this.rawRatioFromTick(binnedTick.toNumber(), roundingMode).lt(rawRatio)
+      ) {
+        binnedTick = binnedTick.add(this.market.tickSpacing);
+      }
+    }
+    return binnedTick.toNumber();
   }
 
   static rawRatioToMantissaExponent(ratio: Big): {

--- a/src/util/tickPriceHelper.ts
+++ b/src/util/tickPriceHelper.ts
@@ -43,6 +43,9 @@ class TickPriceHelper {
 
   /**
    * Inverses the rounding mode for bids.
+   * @param roundingMode the rounding mode to inverse
+   * @returns for asks, returns the rounding mode, for bids, returns the inverse of the rounding mode (roundUp becomes roundDown, roundDown becomes roundUp, and nearest stays nearest).
+   * @remarks This is useful due to ratio for bids being inbound/outbound, and price for bids being outbound/inbound, so, e.g., when rounding price up or down, the tick which determines the ratio should be rounded the opposite direction.
    */
   #inverseRoundingModeForBids(roundingMode: RoundingMode) {
     return this.ba === "asks"

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -44,6 +44,7 @@ class Trade {
         slippage,
         "buy",
       );
+      // round down to not exceed the price
       maxTick = tickPriceHelper.tickFromPrice(priceWithSlippage, "roundDown");
       if ("volume" in params) {
         fillVolume = Big(params.volume);
@@ -416,7 +417,7 @@ class Trade {
     }
 
     if ("price" in params && params.price !== undefined) {
-      // round up to ensure we get at least the price we want for the offer.
+      // round up to ensure we as a maker get what we want for the offer.
       tick = tickPriceHelper.tickFromPrice(Big(params.price), "roundUp");
     }
 

--- a/test/integration/cleaner.integration.test.ts
+++ b/test/integration/cleaner.integration.test.ts
@@ -81,6 +81,7 @@ describe("Cleaner integration tests suite", () => {
       maker,
       tick: askTickPriceHelper.tickFromPrice(
         Big(1).div(rawMinGivesBase.toString()),
+        "nearest",
       ),
       gives: rawMinGivesBase,
       shouldFail: true,
@@ -91,6 +92,7 @@ describe("Cleaner integration tests suite", () => {
       maker,
       tick: askTickPriceHelper.tickFromPrice(
         Big(1).div(rawMinGivesBase.mul(2).toString()),
+        "nearest",
       ),
       gives: rawMinGivesBase.mul(2),
       shouldFail: true,
@@ -172,6 +174,7 @@ describe("Cleaner integration tests suite", () => {
       maker,
       tick: askTickPriceHelper.tickFromPrice(
         Big(1).div(rawMinGivesBase.toString()),
+        "nearest",
       ),
       gives: rawMinGivesBase,
     });
@@ -247,6 +250,7 @@ describe("Cleaner integration tests suite", () => {
       maker,
       tick: askTickPriceHelper.tickFromPrice(
         Big(1).div(rawMinGivesBase.toString()),
+        "nearest",
       ),
       gives: rawMinGivesBase,
       shouldFail: true,
@@ -328,6 +332,7 @@ describe("Cleaner integration tests suite", () => {
       maker,
       tick: askTickPriceHelper.tickFromPrice(
         Big(1).div(rawMinGivesBase.toString()),
+        "nearest",
       ),
       gives: rawMinGivesBase,
       shouldFail: true,

--- a/test/integration/kandel/geometricKandelInstance.integration.test.ts
+++ b/test/integration/kandel/geometricKandelInstance.integration.test.ts
@@ -649,6 +649,7 @@ describe(`${GeometricKandelInstance.prototype.constructor.name} integration test
         index: 0,
         tick: kandel.generalKandelDistributionGenerator.generalDistributionHelper.helper.askTickPriceHelper.tickFromPrice(
           1000,
+          "nearest",
         ),
       });
       const minQuote = await kandel.getMinimumVolumeForIndex({
@@ -656,6 +657,7 @@ describe(`${GeometricKandelInstance.prototype.constructor.name} integration test
         index: 0,
         tick: kandel.generalKandelDistributionGenerator.generalDistributionHelper.helper.bidTickPriceHelper.tickFromPrice(
           1000,
+          "nearest",
         ),
       });
 

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -319,7 +319,11 @@ describe("Market integration tests suite", () => {
         gives: expectedGives,
         tick,
         price,
-        wants: tickPriceHelper.inboundFromOutbound(tick, expectedGives),
+        wants: tickPriceHelper.inboundFromOutbound(
+          tick,
+          expectedGives,
+          "roundDown",
+        ),
         volume: expectedGives,
       };
       mockito
@@ -359,7 +363,11 @@ describe("Market integration tests suite", () => {
         gives: expectedGives,
         tick,
         price: tickPriceHelper.priceFromTick(tick),
-        wants: tickPriceHelper.inboundFromOutbound(tick, expectedGives),
+        wants: tickPriceHelper.inboundFromOutbound(
+          tick,
+          expectedGives,
+          "roundDown",
+        ),
         volume: expectedGives,
       };
       mockito
@@ -480,7 +488,11 @@ describe("Market integration tests suite", () => {
         gives,
         tick,
         price: semiBook.tickPriceHelper.priceFromTick(tick),
-        wants: semiBook.tickPriceHelper.inboundFromOutbound(tick, gives),
+        wants: semiBook.tickPriceHelper.inboundFromOutbound(
+          tick,
+          gives,
+          "roundDown",
+        ),
         volume: new Big(42),
       };
       mockito
@@ -518,7 +530,11 @@ describe("Market integration tests suite", () => {
         gives,
         tick,
         price: semiBook.tickPriceHelper.priceFromTick(tick),
-        wants: semiBook.tickPriceHelper.inboundFromOutbound(tick, gives),
+        wants: semiBook.tickPriceHelper.inboundFromOutbound(
+          tick,
+          gives,
+          "roundDown",
+        ),
         volume: new Big(42),
       };
       mockito
@@ -556,7 +572,11 @@ describe("Market integration tests suite", () => {
         gives: expectedGives,
         tick,
         price: tickPriceHelper.priceFromTick(tick),
-        wants: tickPriceHelper.inboundFromOutbound(tick, expectedGives),
+        wants: tickPriceHelper.inboundFromOutbound(
+          tick,
+          expectedGives,
+          "roundDown",
+        ),
         volume: expectedGives,
       };
       mockito
@@ -704,7 +724,7 @@ describe("Market integration tests suite", () => {
       tick: tick,
       gives: asksGives,
       price: askPrice,
-      wants: askTickHelper.inboundFromOutbound(tick, asksGives),
+      wants: askTickHelper.inboundFromOutbound(tick, asksGives, "roundDown"),
       volume: asksGives,
     };
 
@@ -734,7 +754,7 @@ describe("Market integration tests suite", () => {
       gasbase: market.config().bids.offer_gasbase,
       tick: bidTick,
       gives: bidsGives,
-      wants: bidTickHelper.inboundFromOutbound(bidTick, bidsGives),
+      wants: bidTickHelper.inboundFromOutbound(bidTick, bidsGives, "roundDown"),
       price: bidPrice,
       volume: bidsGives.div(bidPrice),
     };
@@ -1015,6 +1035,7 @@ describe("Market integration tests suite", () => {
               .getBook()
               .asks.tickPriceHelper.tickFromRawRatio(
                 Big(0.000000000002).div(10),
+                "roundDown",
               ),
             fillVolume: 10,
           };
@@ -1176,7 +1197,9 @@ describe("Market integration tests suite", () => {
         tickSpacing: 1,
       });
 
-      const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
+      const price = market
+        .getSemibook("asks")
+        .tickPriceHelper.coercePrice(4, "roundDown");
 
       await waitForTransaction(
         await helpers.newOffer({
@@ -1246,7 +1269,9 @@ describe("Market integration tests suite", () => {
         tickSpacing: 1,
       });
 
-      const price = market.getSemibook("asks").tickPriceHelper.coercePrice(4);
+      const price = market
+        .getSemibook("asks")
+        .tickPriceHelper.coercePrice(4, "roundDown");
       await waitForTransaction(
         await helpers.newOffer({
           mgv,

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -306,7 +306,7 @@ describe("Market integration tests suite", () => {
 
       const tick = 23;
 
-      const price = tickPriceHelper.priceFromTick(23);
+      const price = tickPriceHelper.priceFromTick(23, "nearest");
 
       const offer: Market.Offer = {
         id: 0,
@@ -362,7 +362,7 @@ describe("Market integration tests suite", () => {
         gasbase: 0,
         gives: expectedGives,
         tick,
-        price: tickPriceHelper.priceFromTick(tick),
+        price: tickPriceHelper.priceFromTick(tick, "nearest"),
         wants: tickPriceHelper.inboundFromOutbound(
           tick,
           expectedGives,
@@ -487,7 +487,7 @@ describe("Market integration tests suite", () => {
         gasbase: 0,
         gives,
         tick,
-        price: semiBook.tickPriceHelper.priceFromTick(tick),
+        price: semiBook.tickPriceHelper.priceFromTick(tick, "nearest"),
         wants: semiBook.tickPriceHelper.inboundFromOutbound(
           tick,
           gives,
@@ -529,7 +529,7 @@ describe("Market integration tests suite", () => {
         gasbase: 0,
         gives,
         tick,
-        price: semiBook.tickPriceHelper.priceFromTick(tick),
+        price: semiBook.tickPriceHelper.priceFromTick(tick, "nearest"),
         wants: semiBook.tickPriceHelper.inboundFromOutbound(
           tick,
           gives,
@@ -571,7 +571,7 @@ describe("Market integration tests suite", () => {
         gasbase: 0,
         gives: expectedGives,
         tick,
-        price: tickPriceHelper.priceFromTick(tick),
+        price: tickPriceHelper.priceFromTick(tick, "nearest"),
         wants: tickPriceHelper.inboundFromOutbound(
           tick,
           expectedGives,
@@ -700,8 +700,8 @@ describe("Market integration tests suite", () => {
 
     const asksGives = Big(1);
     let askPrice = Big(2);
-    const tick = askTickHelper.tickFromPrice(askPrice);
-    askPrice = askTickHelper.priceFromTick(tick);
+    const tick = askTickHelper.tickFromPrice(askPrice, "nearest");
+    askPrice = askTickHelper.priceFromTick(tick, "nearest");
 
     await helpers
       .newOffer({
@@ -733,8 +733,8 @@ describe("Market integration tests suite", () => {
     const bidsGives = Big(2);
     let bidPrice = Big(2);
 
-    const bidTick = bidTickHelper.tickFromPrice(bidPrice);
-    bidPrice = bidTickHelper.priceFromTick(bidTick);
+    const bidTick = bidTickHelper.tickFromPrice(bidPrice, "nearest");
+    bidPrice = bidTickHelper.priceFromTick(bidTick, "nearest");
 
     await newOffer({
       mgv,
@@ -907,7 +907,7 @@ describe("Market integration tests suite", () => {
       gives: rawMinGivesBase.mul(2),
     });
     const gave = askTickPriceHelper
-      .priceFromTick(1)
+      .priceFromTick(1, "nearest")
       .mul(market.base.fromUnits(rawMinGivesBase).toNumber())
       .toNumber();
     const buyPromises = await market.buy({
@@ -961,7 +961,7 @@ describe("Market integration tests suite", () => {
     const result = await buyPromises.result;
     result.summary = result.summary as Market.OrderSummary;
     const gave = askTickPriceHelper
-      .priceFromTick(1)
+      .priceFromTick(1, "nearest")
       .mul(market.base.fromUnits(rawMinGivesBase).toNumber())
       .toNumber();
     expect(result.tradeFailures).to.have.lengthOf(0);
@@ -990,14 +990,14 @@ describe("Market integration tests suite", () => {
       market,
       ba: "bids",
       maker,
-      tick: bidTickPriceHelper.tickFromPrice(2),
+      tick: bidTickPriceHelper.tickFromPrice(2, "nearest"),
       gives: rawMinGivesQuote,
     });
     const tx = await mgvTestUtil.postNewOffer({
       market,
       ba: "bids",
       maker,
-      tick: bidTickPriceHelper.tickFromPrice(1),
+      tick: bidTickPriceHelper.tickFromPrice(1, "nearest"),
       gives: rawMinGivesQuote,
     });
 
@@ -1338,7 +1338,7 @@ describe("Market integration tests suite", () => {
       {
         id: 1,
         tick: 1,
-        price: askTickPriceHelper.priceFromTick(1),
+        price: askTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1346,7 +1346,7 @@ describe("Market integration tests suite", () => {
       {
         id: 2,
         tick: 2,
-        price: askTickPriceHelper.priceFromTick(2),
+        price: askTickPriceHelper.priceFromTick(2, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1354,7 +1354,7 @@ describe("Market integration tests suite", () => {
       {
         id: 3,
         tick: 1,
-        price: askTickPriceHelper.priceFromTick(1),
+        price: askTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1362,7 +1362,7 @@ describe("Market integration tests suite", () => {
       {
         id: 4,
         tick: 2,
-        price: askTickPriceHelper.priceFromTick(2),
+        price: askTickPriceHelper.priceFromTick(2, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1370,7 +1370,7 @@ describe("Market integration tests suite", () => {
       {
         id: 5,
         tick: 1,
-        price: askTickPriceHelper.priceFromTick(1),
+        price: askTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1378,7 +1378,7 @@ describe("Market integration tests suite", () => {
       {
         id: 6,
         tick: 3,
-        price: askTickPriceHelper.priceFromTick(3),
+        price: askTickPriceHelper.priceFromTick(3, "nearest"),
         gives: "1",
         gasreq: 9999,
         gasprice: 21000,
@@ -1389,7 +1389,7 @@ describe("Market integration tests suite", () => {
       {
         id: 1,
         tick: 2,
-        price: bidTickPriceHelper.priceFromTick(2),
+        price: bidTickPriceHelper.priceFromTick(2, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,
@@ -1397,7 +1397,7 @@ describe("Market integration tests suite", () => {
       {
         id: 2,
         tick: 1,
-        price: bidTickPriceHelper.priceFromTick(1),
+        price: bidTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,
@@ -1405,7 +1405,7 @@ describe("Market integration tests suite", () => {
       {
         id: 3,
         tick: 2,
-        price: bidTickPriceHelper.priceFromTick(2),
+        price: bidTickPriceHelper.priceFromTick(2, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,
@@ -1413,7 +1413,7 @@ describe("Market integration tests suite", () => {
       {
         id: 4,
         tick: 1,
-        price: bidTickPriceHelper.priceFromTick(1),
+        price: bidTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,
@@ -1421,7 +1421,7 @@ describe("Market integration tests suite", () => {
       {
         id: 5,
         tick: 3,
-        price: bidTickPriceHelper.priceFromTick(3),
+        price: bidTickPriceHelper.priceFromTick(3, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,
@@ -1429,7 +1429,7 @@ describe("Market integration tests suite", () => {
       {
         id: 6,
         tick: 1,
-        price: bidTickPriceHelper.priceFromTick(1),
+        price: bidTickPriceHelper.priceFromTick(1, "nearest"),
         gives: "1",
         gasreq: 10_022,
         gasprice: 30000,

--- a/test/integration/restingOrder.integration.test.ts
+++ b/test/integration/restingOrder.integration.test.ts
@@ -633,7 +633,7 @@ describe("RestingOrder", () => {
         beforeEach(async () => {
           initialTick = orderLP.market
             .getSemibook(ba)
-            .tickPriceHelper.tickFromPrice(initialPrice);
+            .tickPriceHelper.tickFromPrice(initialPrice, "nearest");
           const provision =
             ba === "bids"
               ? await orderLP.computeBidProvision()

--- a/test/integration/semibook.integration.test.ts
+++ b/test/integration/semibook.integration.test.ts
@@ -312,7 +312,7 @@ describe("Semibook integration tests suite", function () {
           });
 
           it("returns correct estimate and residue when cache is empty and offer list is not", async function () {
-            const tick = askTickPriceHelper.tickFromPrice(1);
+            const tick = askTickPriceHelper.tickFromPrice(1, "nearest");
 
             // Post 2 asks
             let tx = await waitForTransaction(
@@ -346,7 +346,10 @@ describe("Semibook integration tests suite", function () {
             const semibook = market.getSemibook("asks");
             expect(semibook.size()).to.equal(0);
 
-            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              tick,
+              "nearest",
+            );
             const given = 1;
 
             const expectedRemainingFillVolume = 0;
@@ -381,7 +384,7 @@ describe("Semibook integration tests suite", function () {
           });
 
           it("returns correct estimate and residue when cache is partial and insufficient while offer list is sufficient", async function () {
-            const tick = askTickPriceHelper.tickFromPrice(1);
+            const tick = askTickPriceHelper.tickFromPrice(1, "nearest");
             // Post 2 asks at different ticks
             let tx = await waitForTransaction(
               newOffer({
@@ -415,7 +418,10 @@ describe("Semibook integration tests suite", function () {
             expect(semibook.size()).to.equal(1);
 
             // Price difference between the two ticks is negligible
-            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              tick,
+              "nearest",
+            );
             const given = 2;
 
             const expectedRemainingFillVolume = 0;
@@ -450,7 +456,7 @@ describe("Semibook integration tests suite", function () {
           });
 
           it("returns correct estimate and residue when cache is partial and offer list is insufficient", async function () {
-            const tick = askTickPriceHelper.tickFromPrice(1);
+            const tick = askTickPriceHelper.tickFromPrice(1, "nearest");
             // Post 2 asks at different ticks
             let tx = await waitForTransaction(
               newOffer({
@@ -484,7 +490,10 @@ describe("Semibook integration tests suite", function () {
             expect(semibook.size()).to.equal(1);
 
             // Price difference between the two ticks is negligible
-            const price = semibook.tickPriceHelper.priceFromTick(tick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              tick,
+              "nearest",
+            );
             const given = 3;
 
             const expectedRemainingFillVolume = 1;
@@ -528,7 +537,7 @@ describe("Semibook integration tests suite", function () {
             });
             const semibook = market.getSemibook("asks");
 
-            const tick = semibook.tickPriceHelper.tickFromPrice(2);
+            const tick = semibook.tickPriceHelper.tickFromPrice(2, "nearest");
             const tx = await waitForTransaction(
               newOffer({
                 mgv,
@@ -563,7 +572,7 @@ describe("Semibook integration tests suite", function () {
             });
             const semibook = market.getSemibook("asks");
 
-            const tick = semibook.tickPriceHelper.tickFromPrice(2);
+            const tick = semibook.tickPriceHelper.tickFromPrice(2, "nearest");
             const tx = await waitForTransaction(
               newOffer({
                 mgv,
@@ -601,8 +610,10 @@ describe("Semibook integration tests suite", function () {
 
             const offerPrice = 2;
             const offerGives = 1;
-            const offerTick =
-              semibook.tickPriceHelper.tickFromPrice(offerPrice);
+            const offerTick = semibook.tickPriceHelper.tickFromPrice(
+              offerPrice,
+              "nearest",
+            );
             const tx = await waitForTransaction(
               newOffer({
                 mgv,
@@ -617,7 +628,10 @@ describe("Semibook integration tests suite", function () {
 
             const expectedRemainingFillVolume = 1;
 
-            const price = semibook.tickPriceHelper.priceFromTick(offerTick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              offerTick,
+              "nearest",
+            );
             const given =
               (to === "buy" ? offerGives : offerGives * offerPrice) +
               expectedRemainingFillVolume;
@@ -651,8 +665,10 @@ describe("Semibook integration tests suite", function () {
 
             const offer1Price = 2;
             const offer1Gives = 1;
-            const offer1Tick =
-              semibook.tickPriceHelper.tickFromPrice(offer1Price);
+            const offer1Tick = semibook.tickPriceHelper.tickFromPrice(
+              offer1Price,
+              "nearest",
+            );
             await waitForTransaction(
               newOffer({
                 mgv,
@@ -664,8 +680,10 @@ describe("Semibook integration tests suite", function () {
             );
             const offer2Price = 2;
             const offer2Gives = 1;
-            const offer2Tick =
-              semibook.tickPriceHelper.tickFromPrice(offer2Price);
+            const offer2Tick = semibook.tickPriceHelper.tickFromPrice(
+              offer2Price,
+              "nearest",
+            );
             const tx = await waitForTransaction(
               newOffer({
                 mgv,
@@ -682,8 +700,10 @@ describe("Semibook integration tests suite", function () {
 
             // Total price will be the average of the offers since they give the same amounts
             const price = semibook.tickPriceHelper
-              .priceFromTick(offer1Tick)
-              .add(semibook.tickPriceHelper.priceFromTick(offer2Tick))
+              .priceFromTick(offer1Tick, "nearest")
+              .add(
+                semibook.tickPriceHelper.priceFromTick(offer2Tick, "nearest"),
+              )
               .div(2);
             const given =
               (to === "buy"
@@ -720,8 +740,10 @@ describe("Semibook integration tests suite", function () {
 
             const offerPrice = 2;
             const offerGives = 2;
-            const offerTick =
-              semibook.tickPriceHelper.tickFromPrice(offerPrice);
+            const offerTick = semibook.tickPriceHelper.tickFromPrice(
+              offerPrice,
+              "nearest",
+            );
             const tx = await waitForTransaction(
               newOffer({
                 mgv,
@@ -736,7 +758,10 @@ describe("Semibook integration tests suite", function () {
 
             const expectedRemainingFillVolume = 0;
 
-            const price = semibook.tickPriceHelper.priceFromTick(offerTick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              offerTick,
+              "nearest",
+            );
             const given =
               (to === "buy" ? offerGives : offerGives * offerPrice) - 1;
 
@@ -770,8 +795,10 @@ describe("Semibook integration tests suite", function () {
 
             const offersPrice = 2;
             const offer1Gives = 1;
-            const offersTick =
-              semibook.tickPriceHelper.tickFromPrice(offersPrice);
+            const offersTick = semibook.tickPriceHelper.tickFromPrice(
+              offersPrice,
+              "nearest",
+            );
             await waitForTransaction(
               newOffer({
                 mgv,
@@ -797,7 +824,10 @@ describe("Semibook integration tests suite", function () {
             const expectedRemainingFillVolume = 0;
 
             // Both offers have same price
-            const price = semibook.tickPriceHelper.priceFromTick(offersTick);
+            const price = semibook.tickPriceHelper.priceFromTick(
+              offersTick,
+              "nearest",
+            );
             const given =
               (to === "buy"
                 ? offer1Gives + offer2Gives
@@ -1154,7 +1184,10 @@ describe("Semibook integration tests suite", function () {
           });
           const semibook = market.getSemibook("asks");
 
-          const tick1 = semibook.tickPriceHelper.tickFromPrice(1.001);
+          const tick1 = semibook.tickPriceHelper.tickFromPrice(
+            1.001,
+            "nearest",
+          );
 
           await waitForTransaction(
             newOffer({
@@ -1166,7 +1199,10 @@ describe("Semibook integration tests suite", function () {
             }),
           );
 
-          const tick2 = semibook.tickPriceHelper.tickFromPrice(1.002);
+          const tick2 = semibook.tickPriceHelper.tickFromPrice(
+            1.002,
+            "nearest",
+          );
 
           const tx = await waitForTransaction(
             newOffer({
@@ -1198,7 +1234,10 @@ describe("Semibook integration tests suite", function () {
           });
           const semibook = market.getSemibook("asks");
 
-          const tick1 = semibook.tickPriceHelper.tickFromPrice(1.001);
+          const tick1 = semibook.tickPriceHelper.tickFromPrice(
+            1.001,
+            "nearest",
+          );
 
           const offer1 = await (
             await newOffer({
@@ -1211,7 +1250,10 @@ describe("Semibook integration tests suite", function () {
           ).wait();
           await waitForBlock(mgv, offer1.blockNumber);
 
-          const tick2 = semibook.tickPriceHelper.tickFromPrice(1.002);
+          const tick2 = semibook.tickPriceHelper.tickFromPrice(
+            1.002,
+            "nearest",
+          );
           await newOffer({
             mgv,
             outbound: "TokenA",
@@ -1307,7 +1349,7 @@ describe("Semibook integration tests suite", function () {
           });
           const semibook = market.getSemibook("asks");
 
-          const tick = semibook.tickPriceHelper.tickFromPrice(1.001);
+          const tick = semibook.tickPriceHelper.tickFromPrice(1.001, "nearest");
           await waitForTransaction(
             newOffer({
               mgv,

--- a/test/integration/semibook.integration.test.ts
+++ b/test/integration/semibook.integration.test.ts
@@ -1401,7 +1401,11 @@ describe("Semibook integration tests suite", function () {
           });
           const semibook = market.getSemibook("asks");
 
-          const tick5 = semibook.tickPriceHelper.tickFromVolumes(1, 5);
+          const tick5 = semibook.tickPriceHelper.tickFromVolumes(
+            1,
+            5,
+            "roundDown",
+          );
           await waitForTransaction(
             newOffer({
               mgv,
@@ -1411,7 +1415,11 @@ describe("Semibook integration tests suite", function () {
               tick: tick5,
             }),
           );
-          const tick4 = semibook.tickPriceHelper.tickFromVolumes(1, 4);
+          const tick4 = semibook.tickPriceHelper.tickFromVolumes(
+            1,
+            4,
+            "roundDown",
+          );
           await waitForTransaction(
             newOffer({
               mgv,
@@ -1421,7 +1429,11 @@ describe("Semibook integration tests suite", function () {
               tick: tick4,
             }),
           );
-          const tick3 = semibook.tickPriceHelper.tickFromVolumes(1, 3);
+          const tick3 = semibook.tickPriceHelper.tickFromVolumes(
+            1,
+            3,
+            "roundDown",
+          );
           await waitForTransaction(
             newOffer({
               mgv,
@@ -1431,7 +1443,11 @@ describe("Semibook integration tests suite", function () {
               tick: tick3,
             }),
           );
-          const tick2 = semibook.tickPriceHelper.tickFromVolumes(1, 2);
+          const tick2 = semibook.tickPriceHelper.tickFromVolumes(
+            1,
+            2,
+            "roundDown",
+          );
           await waitForTransaction(
             newOffer({
               mgv,
@@ -1441,7 +1457,11 @@ describe("Semibook integration tests suite", function () {
               tick: tick2,
             }),
           );
-          const tick1 = semibook.tickPriceHelper.tickFromVolumes(1, 1);
+          const tick1 = semibook.tickPriceHelper.tickFromVolumes(
+            1,
+            1,
+            "roundDown",
+          );
           const tx = await waitForTransaction(
             newOffer({
               mgv,

--- a/test/unit/kandel/generalKandelDistributionGenerator.unit.test.ts
+++ b/test/unit/kandel/generalKandelDistributionGenerator.unit.test.ts
@@ -92,7 +92,9 @@ export function assertConstantWants(
       : distribution.helper.bidTickPriceHelper;
   const values = distribution
     .getLiveOffers(offerType)
-    .map((x) => tickPriceHelper.inboundFromOutbound(x.tick, x.gives));
+    .map((x) =>
+      tickPriceHelper.inboundFromOutbound(x.tick, x.gives, "roundDown"),
+    );
   for (let i = 0; i < values.length; ++i) {
     assertApproxEqRel(expectedValue, values[i], 0.01);
   }

--- a/test/unit/kandel/generalKandelDistributionHelper.unit.test.ts
+++ b/test/unit/kandel/generalKandelDistributionHelper.unit.test.ts
@@ -71,6 +71,7 @@ describe(`${GeneralKandelDistributionHelper.prototype.constructor.name} unit tes
               sut.helper.askTickPriceHelper.inboundFromOutbound(
                 o.tick,
                 o.gives,
+                "roundDown",
               ),
             ).gte(Big(9000)),
             "ask quote should be above minimum",
@@ -83,7 +84,7 @@ describe(`${GeneralKandelDistributionHelper.prototype.constructor.name} unit tes
           );
           assert.ok(
             sut.helper.bidTickPriceHelper
-              .inboundFromOutbound(o.tick, o.gives)
+              .inboundFromOutbound(o.tick, o.gives, "roundDown")
               .gte(Big(1)),
             "bid base should be above minimum",
           );

--- a/test/unit/kandel/geometricKandel/geometricKandelDistributionGenerator.unit.test.ts
+++ b/test/unit/kandel/geometricKandel/geometricKandelDistributionGenerator.unit.test.ts
@@ -555,7 +555,9 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
         assertConstantGives(distribution, "asks", 1);
         distribution.getLiveOffers("asks").forEach((d) => {
           assertApproxEqRel(
-            askTickPriceHelper.inboundFromOutbound(d.tick, d.gives).toNumber(),
+            askTickPriceHelper
+              .inboundFromOutbound(d.tick, d.gives, "roundDown")
+              .toNumber(),
             minPrice.mul(priceRatio.pow(d.index)).toNumber(),
             0.01,
             `wrong quote at ${d.index}`,
@@ -596,7 +598,9 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
         distribution.getLiveOffers("asks").forEach((d, i) => {
           assert.equal(d.gives.toNumber(), 1, `wrong base at ${i}`);
           assertApproxEqRel(
-            askTickPriceHelper.inboundFromOutbound(d.tick, d.gives).toNumber(),
+            askTickPriceHelper
+              .inboundFromOutbound(d.tick, d.gives, "roundDown")
+              .toNumber(),
             minPrice.mul(priceRatio.pow(d.index)).toNumber(),
             0.01,
             `wrong quote at ${d.index}`,
@@ -604,7 +608,9 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
         });
         distribution.getLiveOffers("bids").forEach((d, i) => {
           assertApproxEqRel(
-            bidTickPriceHelper.inboundFromOutbound(d.tick, d.gives).toNumber(),
+            bidTickPriceHelper
+              .inboundFromOutbound(d.tick, d.gives, "roundDown")
+              .toNumber(),
             1,
             0.01,
             `wrong base at ${i}`,
@@ -635,7 +641,9 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
         assertConstantWants(distribution, "asks", 1000);
         distribution.getLiveOffers("bids").forEach((d) => {
           assertApproxEqRel(
-            bidTickPriceHelper.inboundFromOutbound(d.tick, d.gives).toNumber(),
+            bidTickPriceHelper
+              .inboundFromOutbound(d.tick, d.gives, "roundDown")
+              .toNumber(),
             d.gives.div(minPrice.mul(priceRatio.pow(d.index)).toNumber()),
             0.01,
             `wrong bid wants at ${d.index}`,
@@ -645,7 +653,7 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
           assertApproxEqRel(
             d.gives.toNumber(),
             askTickPriceHelper
-              .inboundFromOutbound(d.tick, d.gives)
+              .inboundFromOutbound(d.tick, d.gives, "roundDown")
               .div(minPrice.mul(priceRatio.pow(d.index)).toNumber()),
             0.01,
             `wrong ask gives at ${d.index}`,

--- a/test/unit/kandel/geometricKandel/geometricKandelDistributionGenerator.unit.test.ts
+++ b/test/unit/kandel/geometricKandel/geometricKandelDistributionGenerator.unit.test.ts
@@ -968,7 +968,7 @@ describe(`${GeometricKandelDistributionGenerator.prototype.constructor.name} uni
             tick: (offerType == "asks"
               ? sut.geometricDistributionHelper.helper.askTickPriceHelper
               : sut.geometricDistributionHelper.helper.bidTickPriceHelper
-            ).tickFromPrice(4000),
+            ).tickFromPrice(4000, "nearest"),
             stepSize: 1,
             pricePoints: 10,
             baseQuoteTickOffset:

--- a/test/unit/kandel/geometricKandel/geometricKandelDistributionHelper.unit.test.ts
+++ b/test/unit/kandel/geometricKandel/geometricKandelDistributionHelper.unit.test.ts
@@ -70,12 +70,15 @@ describe(`${GeometricKandelDistributionHelper.prototype.constructor.name} unit t
     GeometricKandelDistributionHelper.prototype.calculateBaseQuoteTickOffset
       .name,
     () => {
-      it("can calculate based on price ratio", () => {
+      it("can calculate based on price ratio and rounds down", () => {
+        // Arrange
+        sut.helper.market.tickSpacing = 2;
+
         // Act
         const actual = sut.calculateBaseQuoteTickOffset(Big(1.08));
 
         // Assert
-        assert.equal(actual, 769);
+        assert.equal(actual, 768);
       });
 
       it("calculates an offset that is a multiple of tickSpacing", () => {
@@ -86,7 +89,7 @@ describe(`${GeometricKandelDistributionHelper.prototype.constructor.name} unit t
         const actual = sut.calculateBaseQuoteTickOffset(Big(1.08));
 
         // Assert
-        assert.equal(actual, 770);
+        assert.equal(actual, 763);
       });
 
       it("Fails if less than 1", () => {
@@ -125,11 +128,11 @@ describe(`${GeometricKandelDistributionHelper.prototype.constructor.name} unit t
         const baseQuoteTickOffset = 769;
         const priceRatio = 1.08;
         const pricePoints = 7;
-        const maxBaseQuoteTick = 119759;
-        const minBaseQuoteTick = 115145;
+        const maxBaseQuoteTick = 119760;
+        const minBaseQuoteTick = 115146;
         const midBaseQuoteTick = 117453;
         const minPrice = Big(1001);
-        const maxPrice = Big(1587.841870262581);
+        const maxPrice = Big(1588.000654449607);
         const midPrice = Big(1260.971712);
 
         const expectedParams = {
@@ -202,13 +205,13 @@ describe(`${GeometricKandelDistributionHelper.prototype.constructor.name} unit t
         // Arrange
         sut.helper.market.tickSpacing = 7;
         const baseQuoteTickOffset = 770;
-        const priceRatio = 1.08;
+        const priceRatio = 1.0805;
         const pricePoints = 7;
         const maxBaseQuoteTick = 119770;
         const minBaseQuoteTick = 115150;
         const midBaseQuoteTick = 117453;
         const minPrice = Big(1001);
-        const maxPrice = Big(1589);
+        const maxPrice = Big(1590);
         const midPrice = Big(1260.971712);
 
         const expectedParams = {
@@ -274,6 +277,66 @@ describe(`${GeometricKandelDistributionHelper.prototype.constructor.name} unit t
             midBaseQuoteTick,
           }),
           expectedParams,
+        );
+      });
+
+      it("uses correct rounding for min, mid, and max price to tick conversion", () => {
+        // Arrange
+        sut.helper.market.tickSpacing = 7;
+        const minPrice = Big(1001);
+        const maxPrice = Big(1589.58935);
+        const midPrice = Big(1260.971712);
+        const baseQuoteTickOffset = 770;
+        const minBaseQuoteTick = 115150;
+        const midBaseQuoteTick = 117453;
+
+        // Act
+        const result = sut.getTickDistributionParams({
+          minPrice,
+          maxPrice,
+          midPrice,
+          baseQuoteTickOffset,
+        });
+
+        // Assert
+        assert.equal(
+          result.minBaseQuoteTick,
+          Math.ceil(minBaseQuoteTick / 7) * 7,
+        );
+        assert.equal(
+          result.midBaseQuoteTick,
+          Math.ceil(midBaseQuoteTick / 7) * 7,
+        );
+        assert.equal(result.pricePoints, 6);
+      });
+
+      it("mid price to tick conversion can round down", () => {
+        // Arrange
+        const baseQuoteTickOffset = 770;
+        const minBaseQuoteTick = 115150;
+        const maxBaseQuoteTick = 119760;
+        const midPrice = Big(1260.97);
+        const midBaseQuoteTick = sut.getTickDistributionParams({
+          minBaseQuoteTick,
+          maxBaseQuoteTick,
+          midPrice,
+          baseQuoteTickOffset,
+        }).midBaseQuoteTick;
+
+        sut.helper.market.tickSpacing = 7;
+
+        // Act
+        const result = sut.getTickDistributionParams({
+          minBaseQuoteTick,
+          maxBaseQuoteTick,
+          midPrice,
+          baseQuoteTickOffset,
+        });
+
+        // Assert
+        assert.equal(
+          result.midBaseQuoteTick,
+          Math.floor(midBaseQuoteTick / 7) * 7,
         );
       });
 

--- a/test/unit/kandel/geometricKandel/geometricKandelStatus.unit.test.ts
+++ b/test/unit/kandel/geometricKandel/geometricKandelStatus.unit.test.ts
@@ -227,6 +227,7 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
               price:
                 sut.geometricDistributionHelper.helper.askTickPriceHelper.priceFromTick(
                   expectedBaseQuoteTick,
+                  "nearest",
                 ),
               tick: expectedBaseQuoteTick,
             }
@@ -238,6 +239,7 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
               price:
                 sut.geometricDistributionHelper.helper.bidTickPriceHelper.priceFromTick(
                   -expectedBaseQuoteTick,
+                  "nearest",
                 ),
               tick: -expectedBaseQuoteTick,
             }
@@ -248,6 +250,7 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
           expectedPrice:
             sut.geometricDistributionHelper.helper.askTickPriceHelper.priceFromTick(
               expectedBaseQuoteTick,
+              "nearest",
             ),
           expectedBaseQuoteTick: expectedBaseQuoteTick,
           asks,
@@ -275,9 +278,15 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
         },
         expectedLiveOutOfRange: [],
         expectedMinPrice: Big(1000),
-        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(1000),
+        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          1000,
+          "nearest",
+        ),
         expectedMaxPrice: Big(32000),
-        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(32000),
+        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          32000,
+          "nearest",
+        ),
         expectedStatuses: expectedStatuses,
         expectedBaseQuoteTickOffset:
           sut.geometricDistributionHelper.calculateBaseQuoteTickOffset(
@@ -312,18 +321,18 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
           bids: [
             {
               index: 0,
-              tick: bidTickPriceHelper.tickFromPrice(1000),
+              tick: bidTickPriceHelper.tickFromPrice(1000, "nearest"),
               id: 43,
               live: false,
             },
             {
-              tick: bidTickPriceHelper.tickFromPrice(2000),
+              tick: bidTickPriceHelper.tickFromPrice(2000, "nearest"),
               index: 1,
               id: 42,
               live: true,
             },
             {
-              tick: bidTickPriceHelper.tickFromPrice(15000),
+              tick: bidTickPriceHelper.tickFromPrice(15000, "nearest"),
               index: 4,
               id: 55,
               live: true,
@@ -341,9 +350,15 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
           id: 42,
         },
         expectedMinPrice: Big(1000),
-        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(1000),
+        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          1000,
+          "nearest",
+        ),
         expectedMaxPrice: Big(32000),
-        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(32000),
+        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          32000,
+          "nearest",
+        ),
         expectedLiveOutOfRange: [],
         expectedBaseQuoteTickOffset: baseQuoteTickOffset,
         expectedPriceRatio:
@@ -354,23 +369,29 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
           {
             expectedLiveBid: true,
             expectedPrice: Big(1000),
-            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(1000),
+            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(
+              1000,
+              "nearest",
+            ),
             bids: {
               live: false,
               id: 43,
               price: Big(1000),
-              tick: bidTickPriceHelper.tickFromPrice(1000),
+              tick: bidTickPriceHelper.tickFromPrice(1000, "nearest"),
             },
           },
           {
             expectedLiveBid: true,
             expectedPrice: Big(2000),
-            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(2000),
+            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(
+              2000,
+              "nearest",
+            ),
             bids: {
               live: true,
               id: 42,
               price: Big(2000),
-              tick: bidTickPriceHelper.tickFromPrice(2000),
+              tick: bidTickPriceHelper.tickFromPrice(2000, "nearest"),
             },
           },
           {
@@ -391,7 +412,7 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
               live: true,
               id: 55,
               price: Big(15000),
-              tick: bidTickPriceHelper.tickFromPrice(15000),
+              tick: bidTickPriceHelper.tickFromPrice(15000, "nearest"),
             },
           },
           {
@@ -453,19 +474,19 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
             {
               bids: [
                 {
-                  tick: bidTickPriceHelper.tickFromPrice(1000),
+                  tick: bidTickPriceHelper.tickFromPrice(1000, "nearest"),
                   index: 0,
                   id: 42,
                   live: true,
                 },
                 {
-                  tick: bidTickPriceHelper.tickFromPrice(2000),
+                  tick: bidTickPriceHelper.tickFromPrice(2000, "nearest"),
                   index: 1,
                   id: 43,
                   live: dead < 3,
                 },
                 {
-                  tick: bidTickPriceHelper.tickFromPrice(4000),
+                  tick: bidTickPriceHelper.tickFromPrice(4000, "nearest"),
                   index: 2,
                   id: 44,
                   live: dead < 1,
@@ -473,19 +494,19 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
               ],
               asks: [
                 {
-                  tick: askTickPriceHelper.tickFromPrice(8000),
+                  tick: askTickPriceHelper.tickFromPrice(8000, "nearest"),
                   index: 3,
                   id: 45,
                   live: dead < 2,
                 },
                 {
-                  tick: askTickPriceHelper.tickFromPrice(16000),
+                  tick: askTickPriceHelper.tickFromPrice(16000, "nearest"),
                   index: 4,
                   id: 46,
                   live: dead < 4,
                 },
                 {
-                  tick: askTickPriceHelper.tickFromPrice(32000),
+                  tick: askTickPriceHelper.tickFromPrice(32000, "nearest"),
                   index: 5,
                   id: 47,
                   live: true,
@@ -540,13 +561,13 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
         {
           bids: [
             {
-              tick: bidTickPriceHelper.tickFromPrice(5000),
+              tick: bidTickPriceHelper.tickFromPrice(5000, "nearest"),
               index: 3,
               id: 42,
               live: true,
             },
             {
-              tick: bidTickPriceHelper.tickFromPrice(2000),
+              tick: bidTickPriceHelper.tickFromPrice(2000, "nearest"),
               index: 1,
               id: 43,
               live: true,
@@ -560,8 +581,14 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
       assertStatuses({
         expectedMinPrice: Big(1000),
         expectedMaxPrice: Big(2000),
-        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(1000),
-        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(Big(2000)),
+        expectedMinBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          1000,
+          "nearest",
+        ),
+        expectedMaxBaseQuoteTick: askTickPriceHelper.tickFromPrice(
+          2000,
+          "nearest",
+        ),
         expectedBaseOffer: {
           offerType: "bids",
           index: 1,
@@ -577,17 +604,23 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
           {
             expectedLiveBid: true,
             expectedPrice: Big(1000),
-            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(Big(1000)),
+            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(
+              1000,
+              "nearest",
+            ),
           },
           {
             expectedLiveBid: true,
             expectedPrice: Big(2000),
-            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(Big(2000)),
+            expectedBaseQuoteTick: -bidTickPriceHelper.tickFromPrice(
+              2000,
+              "nearest",
+            ),
             bids: {
               live: true,
               id: 43,
               price: Big(2000),
-              tick: bidTickPriceHelper.tickFromPrice(Big(2000)),
+              tick: bidTickPriceHelper.tickFromPrice(2000, "nearest"),
             },
           },
         ],
@@ -601,6 +634,7 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
         const midPrice =
           sut.geometricDistributionHelper.helper.bidTickPriceHelper.priceFromTick(
             roundUpScenario ? 6 : 8,
+            "nearest",
           );
         const offerTick = 7;
         sut.geometricDistributionHelper.helper.askTickPriceHelper.market.tickSpacing = 7;

--- a/test/unit/kandel/geometricKandel/geometricKandelStatus.unit.test.ts
+++ b/test/unit/kandel/geometricKandel/geometricKandelStatus.unit.test.ts
@@ -594,5 +594,33 @@ describe(`${GeometricKandelStatus.prototype.constructor.name} unit tests suite`,
         statuses,
       });
     });
+
+    [true, false].forEach((roundUpScenario) => {
+      it(`rounds mid price to nearest (roundUpScenario=${roundUpScenario})`, () => {
+        // Arrange
+        const midPrice =
+          sut.geometricDistributionHelper.helper.bidTickPriceHelper.priceFromTick(
+            roundUpScenario ? 6 : 8,
+          );
+        const offerTick = 7;
+        sut.geometricDistributionHelper.helper.askTickPriceHelper.market.tickSpacing = 7;
+
+        // Act
+        const statuses = sut.getOfferStatuses(midPrice, 770, 2, 1, {
+          bids: [
+            {
+              tick: offerTick,
+              index: 0,
+              id: 42,
+              live: true,
+            },
+          ],
+          asks: [],
+        });
+
+        // Assert
+        assert.equal(statuses.statuses[0].expectedLiveBid, true);
+      });
+    });
   });
 });

--- a/test/unit/kandel/kandelDistributionHelper.unit.test.ts
+++ b/test/unit/kandel/kandelDistributionHelper.unit.test.ts
@@ -36,8 +36,8 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
         const { askGives, bidGives } = sut.calculateMinimumInitialGives(
           Big(1),
           Big(1000),
-          [sut.bidTickPriceHelper.tickFromPrice(1000)],
-          [sut.askTickPriceHelper.tickFromPrice(1000)],
+          [sut.bidTickPriceHelper.tickFromPrice(1000, "nearest")],
+          [sut.askTickPriceHelper.tickFromPrice(1000, "nearest")],
         );
 
         // Assert
@@ -47,7 +47,7 @@ describe(`${KandelDistributionHelper.prototype.constructor.name} unit tests suit
 
       it("returns higher than minimum if dual at some price would be below its minimum", () => {
         const baseQuoteTicks = [Big(2000), Big(1000), Big(500), Big(4000)].map(
-          (x) => sut.askTickPriceHelper.tickFromPrice(x),
+          (x) => sut.askTickPriceHelper.tickFromPrice(x, "nearest"),
         );
 
         // Act

--- a/test/unit/liquidityProvider.unit.test.ts
+++ b/test/unit/liquidityProvider.unit.test.ts
@@ -5,7 +5,7 @@ import { TokenCalculations } from "../../src/token";
 
 describe("Liquidity provider unit tests suite", () => {
   it("normalizeOfferParams, with gives, tick, asks and funding", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         tick: 1,
@@ -18,13 +18,12 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 1.0001);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, 1);
     assert.deepStrictEqual(tick, 1);
   });
   it("normalizeOfferParams, with gives, tick, bids and no funding", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         tick: -1,
@@ -36,14 +35,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 1.0001);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, with non-equal decimals gives, tick, bids and no funding", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         tick: -1,
@@ -56,14 +54,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), Big(0.010001).toNumber());
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, with volume and price 1, as asks", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         volume: 1,
@@ -75,14 +72,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 1);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -276325);
   });
 
   it("normalizeOfferParams, with volume and price 1, as bids", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         volume: 1,
@@ -94,14 +90,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 1);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 276324);
   });
 
   it("normalizeOfferParams, with volume and price 2, as asks", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         volume: 1, // base
@@ -113,14 +108,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 2);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 6931);
   });
 
   it("normalizeOfferParams, with volume and price 2, as bids", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         volume: 1, //base
@@ -132,14 +126,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 2);
     assert.deepStrictEqual(gives, Big(2));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -6932);
   });
 
   it("normalizeOfferParams, with volume and price 2, as asks", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         volume: 1, // base
@@ -151,14 +144,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 2);
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 6931);
   });
 
   it("normalizeOfferParams, with volume and price 2, as bids", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         volume: 1, //base
@@ -170,14 +162,13 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toNumber(), 2);
     assert.deepStrictEqual(gives, Big(2));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -6932);
   });
 
   it("normalizeOfferParams, with gives and wants, as bids", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         gives: 20, // quote
@@ -189,13 +180,12 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toFixed(4), (20 / 30).toFixed(4));
     assert.deepStrictEqual(gives, Big(20));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 280378);
   });
   it("normalizeOfferParams, with gives and wants, as asks", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 20,
@@ -207,13 +197,12 @@ describe("Liquidity provider unit tests suite", () => {
         tickSpacing: 1,
       },
     );
-    assert.equal(price.toFixed(4), (30 / 20).toFixed(4));
     assert.deepStrictEqual(gives, Big(20));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -272270);
   });
   it("normalizeOfferParams, with big gives and wants, as asks", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 20000,
@@ -226,14 +215,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), (30000 / 20000).toFixed(4));
     assert.deepStrictEqual(gives, Big(20000));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -272270);
   });
 
   it("normalizeOfferParams, ask tick = 0 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 1,
@@ -246,14 +234,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "1.0000");
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 0);
   });
 
   it("normalizeOfferParams, ask tick = 0 price = 10 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 1, // base
@@ -267,14 +254,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "10.0000");
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 0);
   });
 
   it("normalizeOfferParams, ask with tick = 1 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 1, // base
@@ -287,14 +273,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "1.0001");
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 1);
   });
 
   it("normalizeOfferParams, ask with tick = 1 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 100, // base
@@ -307,14 +292,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), (1.0001 / 100).toFixed(4));
     assert.deepStrictEqual(gives, Big(100));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 1);
   });
 
   it("normalizeOfferParams, ask with tick = -1 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         wants: 1,
@@ -327,14 +311,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), (1 / 1.0001).toFixed(4));
     assert.deepStrictEqual(gives, Big(1.0001));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, ask with tick = -1 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "asks",
         gives: 1.0001,
@@ -347,14 +330,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "99.9900");
     assert.deepStrictEqual(gives, Big(1.0001));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, bid tick = 0 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 1,
@@ -368,14 +350,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "1.0000");
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 0);
   });
 
   it("normalizeOfferParams, bid tick = 0 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 1, // base
@@ -388,14 +369,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "10.0000");
     assert.deepStrictEqual(gives, Big(10));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 0);
   });
 
   it("normalizeOfferParams, ask tick = 0 price = 10 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 1, // base
@@ -408,14 +388,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "10.0000");
     assert.deepStrictEqual(gives, Big(10));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 0);
   });
 
   it("normalizeOfferParams, ask with tick = -1 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 1, // base
@@ -428,14 +407,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "1.0001");
     assert.deepStrictEqual(gives, Big(1.0001));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, ask with tick = -1 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 100, // base
@@ -448,14 +426,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "0.0100");
     assert.deepStrictEqual(gives, Big(1.0001));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, -1);
   });
 
   it("normalizeOfferParams, ask with tick = 1 same decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         gives: 1,
@@ -468,14 +445,13 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "0.9999");
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 1);
   });
 
   it("normalizeOfferParams, ask with tick = 1 different decimals", async function () {
-    const { tick, gives, price, fund } = LiquidityProvider.normalizeOfferParams(
+    const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(
       {
         ba: "bids",
         wants: 1.0001,
@@ -488,7 +464,6 @@ describe("Liquidity provider unit tests suite", () => {
       },
     );
 
-    assert.equal(price.toFixed(4), "99.9900");
     assert.deepStrictEqual(gives, Big(100));
     assert.deepStrictEqual(fund, undefined);
     assert.deepStrictEqual(tick, 1);

--- a/test/unit/liquidityProvider.unit.test.ts
+++ b/test/unit/liquidityProvider.unit.test.ts
@@ -69,12 +69,12 @@ describe("Liquidity provider unit tests suite", () => {
       {
         base: new TokenCalculations(18, 18),
         quote: new TokenCalculations(6, 6),
-        tickSpacing: 1,
+        tickSpacing: 100,
       },
     );
     assert.deepStrictEqual(gives, Big(1));
     assert.deepStrictEqual(fund, undefined);
-    assert.deepStrictEqual(tick, -276325);
+    assert.deepStrictEqual(tick, -276400);
   });
 
   it("normalizeOfferParams, with volume and price 1, as bids", async function () {
@@ -177,12 +177,12 @@ describe("Liquidity provider unit tests suite", () => {
       {
         base: new TokenCalculations(18, 18),
         quote: new TokenCalculations(6, 6),
-        tickSpacing: 1,
+        tickSpacing: 100,
       },
     );
     assert.deepStrictEqual(gives, Big(20));
     assert.deepStrictEqual(fund, undefined);
-    assert.deepStrictEqual(tick, 280378);
+    assert.deepStrictEqual(tick, 280300);
   });
   it("normalizeOfferParams, with gives and wants, as asks", async function () {
     const { tick, gives, fund } = LiquidityProvider.normalizeOfferParams(

--- a/test/unit/market.unit.test.ts
+++ b/test/unit/market.unit.test.ts
@@ -123,7 +123,7 @@ describe("Market unit tests suite", () => {
           base: new TokenCalculations(0, 0),
           quote: new TokenCalculations(0, 0),
           tickSpacing: 1,
-        }).tickFromRawRatio(priceBig),
+        }).tickFromRawRatio(priceBig, "roundDown"),
         price: Big(price),
         volume: Big(42),
       };

--- a/test/unit/semibook.unit.test.ts
+++ b/test/unit/semibook.unit.test.ts
@@ -94,7 +94,7 @@ describe("Semibook unit test suite", () => {
       assert.equal(result, false);
     });
 
-    it("returns false, when what is base and to is buy ", async function () {
+    it("returns false, when what is base and to is buy", async function () {
       //Arrange
       const opts: Market.BookOptions = {
         desiredVolume: {
@@ -109,7 +109,7 @@ describe("Semibook unit test suite", () => {
       assert.equal(result, false);
     });
 
-    it("returns true, when what is base and to is sell ", async function () {
+    it("returns true, when what is base and to is sell", async function () {
       //Arrange
       const opts: Market.BookOptions = {
         desiredVolume: {
@@ -124,7 +124,7 @@ describe("Semibook unit test suite", () => {
       assert.equal(result, true);
     });
 
-    it("returns false, when what is quote and to is sell ", async function () {
+    it("returns false, when what is quote and to is sell", async function () {
       //Arrange
       const opts: Market.BookOptions = {
         desiredVolume: {
@@ -139,7 +139,7 @@ describe("Semibook unit test suite", () => {
       assert.equal(result, false);
     });
 
-    it("returns true, when what is quote and to is buy ", async function () {
+    it("returns true, when what is quote and to is buy", async function () {
       //Arrange
       const opts: Market.BookOptions = {
         desiredVolume: {

--- a/test/unit/semibook.unit.test.ts
+++ b/test/unit/semibook.unit.test.ts
@@ -269,7 +269,7 @@ describe("Semibook unit test suite", () => {
           quote,
           tickSpacing: instance(marketMock).tickSpacing,
         });
-        const expectedPrice = tickPriceHelper.priceFromTick(rawTick);
+        const expectedPrice = tickPriceHelper.priceFromTick(rawTick, "nearest");
 
         const expectedGives = UnitCalculations.fromUnits(
           rawGives,

--- a/test/unit/tickPriceHelper.unit.test.ts
+++ b/test/unit/tickPriceHelper.unit.test.ts
@@ -192,7 +192,7 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
         );
 
         // Act
-        const result = tickPriceHelper.priceFromTick(tick);
+        const result = tickPriceHelper.priceFromTick(tick, "nearest");
         // Assert
         assert.equal(
           result.toPrecision(comparisonPrecision).toString(),
@@ -263,7 +263,7 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
         );
 
         // Act
-        const result = tickPriceHelper.tickFromPrice(price);
+        const result = tickPriceHelper.tickFromPrice(price, "nearest");
         // Assert
         assert.equal(coercedTick ?? tick, result);
       });
@@ -349,8 +349,14 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
     //assert.ok(Math.abs(Big(1.0001).pow(rawAskTick).toNumber() - rawAskRatio) < 0.1);
     //assert.ok(Math.abs(Big(1.0001).pow(rawBidTick).toNumber() - rawBidRatio.toNumber()) < 0.1);
 
-    const calcAskTick = askTickPriceHelper.tickFromPrice(displayPrice);
-    const calcBidTick = bidTickPriceHelper.tickFromPrice(displayPrice);
+    const calcAskTick = askTickPriceHelper.tickFromPrice(
+      displayPrice,
+      "nearest",
+    );
+    const calcBidTick = bidTickPriceHelper.tickFromPrice(
+      displayPrice,
+      "nearest",
+    );
 
     // relate tickFromPrice to tickFromVolumes
     const calcAskTickFromVolumes = askTickPriceHelper.tickFromVolumes(
@@ -386,8 +392,14 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
       "rawBidTick not equal to bid tick calculated from price",
     );
 
-    const calcAskPrice = askTickPriceHelper.priceFromTick(rawAskTick);
-    const calcBidPrice = bidTickPriceHelper.priceFromTick(rawBidTick);
+    const calcAskPrice = askTickPriceHelper.priceFromTick(
+      rawAskTick,
+      "nearest",
+    );
+    const calcBidPrice = bidTickPriceHelper.priceFromTick(
+      rawBidTick,
+      "nearest",
+    );
 
     assertApproxEqAbs(displayPrice, calcAskPrice.toNumber(), 0.01);
     assertApproxEqAbs(displayPrice, calcBidPrice.toNumber(), 0.01);
@@ -510,7 +522,8 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
 
         // Act
         const result = tickPriceHelper.tickFromPrice(
-          tickPriceHelper.priceFromTick(tick),
+          tickPriceHelper.priceFromTick(tick, "nearest"),
+          "nearest",
         );
 
         // Assert
@@ -530,21 +543,24 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
 
         // Act
         const resultPrice = tickPriceHelper.priceFromTick(
-          tickPriceHelper.tickFromPrice(price),
+          tickPriceHelper.tickFromPrice(price, "nearest"),
+          "nearest",
         );
 
         const resultPriceTickPlusOne = tickPriceHelper.priceFromTick(
-          tickPriceHelper.tickFromPrice(price) +
+          tickPriceHelper.tickFromPrice(price, "nearest") +
             (args.ba == "bids"
               ? -args.market.tickSpacing
               : args.market.tickSpacing),
+          "nearest",
         );
 
         const resultPriceTickMinusOne = tickPriceHelper.priceFromTick(
-          tickPriceHelper.tickFromPrice(price) +
+          tickPriceHelper.tickFromPrice(price, "nearest") +
             (args.ba == "bids"
               ? args.market.tickSpacing
               : -args.market.tickSpacing),
+          "nearest",
         );
 
         const roundedPrice = Big(price).round(comparisonPrecision);
@@ -574,7 +590,8 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
         const result = tickPriceHelper.coercePrice(price, "nearest");
         tickPriceHelper.market.tickSpacing = 1;
         const priceRoundTrip = tickPriceHelper.priceFromTick(
-          tickPriceHelper.tickFromPrice(result),
+          tickPriceHelper.tickFromPrice(result, "nearest"),
+          "nearest",
         );
 
         // Assert - since price is coerced it should not change on a roundtrip - except off by one tick
@@ -682,7 +699,7 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
             const [outbound, expectedInbound] =
               ba == "asks" ? [base, quote] : [quote, base];
 
-            const tick = tickPriceHelper.tickFromPrice(price);
+            const tick = tickPriceHelper.tickFromPrice(price, "nearest");
             // Act
             const result = tickPriceHelper.inboundFromOutbound(
               tick,
@@ -714,7 +731,7 @@ describe(`${TickPriceHelper.prototype.constructor.name} unit tests suite`, () =>
             const [expectedOutbound, inbound] =
               ba == "asks" ? [base, quote] : [quote, base];
 
-            const tick = tickPriceHelper.tickFromPrice(price);
+            const tick = tickPriceHelper.tickFromPrice(price, "nearest");
             // Act
             const result = tickPriceHelper.outboundFromInbound(
               tick,

--- a/test/unit/trade.unit.test.ts
+++ b/test/unit/trade.unit.test.ts
@@ -173,7 +173,7 @@ describe("Trade unit tests suite", () => {
       );
     });
 
-    it("returns fillVolume as fillVolume, tick corrected for slippage and fillWants as fillWants, when params has tick, fillVolume and fillWants ", async function () {
+    it("returns fillVolume as fillVolume, tick corrected for slippage and fillWants as fillWants, when params has tick, fillVolume and fillWants", async function () {
       //Arrange
       const trade = new Trade();
       const spyTrade = spy(trade);
@@ -225,7 +225,7 @@ describe("Trade unit tests suite", () => {
       assert.equal(result.fillWants, params.fillWants);
     });
 
-    it("returns gives adjusted for slippage as fillVolume, tick corrected for slippage and fillWants as fillWants, when params has gives, wants and fillWants ", async function () {
+    it("returns gives adjusted for slippage as fillVolume, tick corrected for slippage and fillWants as fillWants, when params has gives, wants and fillWants", async function () {
       //Arrange
       const trade = new Trade();
       const spyTrade = spy(trade);
@@ -260,6 +260,7 @@ describe("Trade unit tests suite", () => {
       const expectedTick = tickPriceHelper.tickFromVolumes(
         givesWithSlippage,
         params.wants,
+        "roundDown",
       );
 
       assert.equal(
@@ -507,7 +508,7 @@ describe("Trade unit tests suite", () => {
       assert.equal(result.fillWants, true);
     });
 
-    it("returns fillVolume as gives, tick corrected for slippage and fillWants as fillWants, when params has gives, wants and fillWants ", async function () {
+    it("returns fillVolume as gives, tick corrected for slippage and fillWants as fillWants, when params has gives, wants and fillWants", async function () {
       //Arrange
       const trade = new Trade();
       const spyTrade = spy(trade);
@@ -550,6 +551,7 @@ describe("Trade unit tests suite", () => {
       const expectedTick = tickPriceHelper.tickFromVolumes(
         params.gives,
         wantsWithSlippage,
+        "roundDown",
       );
 
       assert.equal(

--- a/test/unit/trade.unit.test.ts
+++ b/test/unit/trade.unit.test.ts
@@ -20,7 +20,7 @@ describe("Trade unit tests suite", () => {
       market = {
         base: new TokenCalculations(18, 18),
         quote: new TokenCalculations(12, 12),
-        tickSpacing: 1,
+        tickSpacing: 100,
       };
       trade = new Trade();
       tickPriceHelper = new TickPriceHelper("asks", market);
@@ -42,6 +42,7 @@ describe("Trade unit tests suite", () => {
         Big(params.limitPrice)
           .mul(100 + slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -72,6 +73,7 @@ describe("Trade unit tests suite", () => {
         Big(params.limitPrice)
           .mul(100 + slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -102,6 +104,7 @@ describe("Trade unit tests suite", () => {
           .priceFromTick(params.maxTick)
           .mul(100 + slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -133,6 +136,7 @@ describe("Trade unit tests suite", () => {
           .priceFromTick(params.maxTick)
           .mul(100 + slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -204,7 +208,7 @@ describe("Trade unit tests suite", () => {
       market = {
         base: new TokenCalculations(18, 18),
         quote: new TokenCalculations(12, 12),
-        tickSpacing: 1,
+        tickSpacing: 100,
       };
       trade = new Trade();
       tickPriceHelper = new TickPriceHelper("bids", market);
@@ -283,9 +287,10 @@ describe("Trade unit tests suite", () => {
       // Assert
       const expectedTickWithSlippage = tickPriceHelper.tickFromPrice(
         tickPriceHelper
-          .priceFromTick(params.maxTick)
+          .priceFromTick(params.maxTick, "roundUp")
           .mul(100 - slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -314,9 +319,10 @@ describe("Trade unit tests suite", () => {
       // Assert
       const expectedTickWithSlippage = tickPriceHelper.tickFromPrice(
         tickPriceHelper
-          .priceFromTick(params.maxTick)
+          .priceFromTick(params.maxTick, "roundUp")
           .mul(100 - slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(

--- a/test/unit/trade.unit.test.ts
+++ b/test/unit/trade.unit.test.ts
@@ -101,7 +101,7 @@ describe("Trade unit tests suite", () => {
       //Assert
       const expectedTickWithSlippage = tickPriceHelper.tickFromPrice(
         tickPriceHelper
-          .priceFromTick(params.maxTick)
+          .priceFromTick(params.maxTick, "roundDown")
           .mul(100 + slippage)
           .div(100),
         "roundDown",
@@ -133,7 +133,7 @@ describe("Trade unit tests suite", () => {
       //Assert
       const expectedTickWithSlippage = tickPriceHelper.tickFromPrice(
         tickPriceHelper
-          .priceFromTick(params.maxTick)
+          .priceFromTick(params.maxTick, "roundDown")
           .mul(100 + slippage)
           .div(100),
         "roundDown",
@@ -230,6 +230,7 @@ describe("Trade unit tests suite", () => {
         Big(params.limitPrice)
           .mul(100 - slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(
@@ -260,6 +261,7 @@ describe("Trade unit tests suite", () => {
         Big(params.limitPrice)
           .mul(100 - slippage)
           .div(100),
+        "roundDown",
       );
 
       assert.equal(

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -165,7 +165,7 @@ export const newOffer = async (
       base: baseToken,
       quote: quoteToken,
       tickSpacing: 1,
-    }).tickFromPrice(price);
+    }).tickFromPrice(price, "nearest");
   } else {
     const { outbound: outbound_tkn, inbound: inbound_tkn } = params;
     tick = params.tick;


### PR DESCRIPTION
Review commit-by-commit, see header.

`feat(tickSpacing): Add rounding up/down` contains the bulk of the rounding changes and some test changes (and a ninja-rename), but subsequent commits add more tests.

Semibook changes are not tested as we have no unit tests for the changed functions and we have no market with tickSpacing>1