### PR TITLE
feat: Add Mangrove.getRestingOrderRouterAddress and update mangrove-deployments to 2.0.1-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- feat: Add `Mangrove.getRestingOrderRouterAddress` which gets the address of the router contract for resting orders belonging to the connected user (`Mangrove.signer`).
+
 # 2.0.5-2
 
 - Upgrade to mangrove-deployments v2.0.1-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - feat: Add `Mangrove.getRestingOrderRouterAddress` which gets the address of the router contract for resting orders belonging to the connected user (`Mangrove.signer`).
+- Upgrade to mangrove-deployments v2.0.1-2
 
 # 2.0.5-2
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@ethersproject/experimental": "^5.7.0",
     "@mangrovedao/context-addresses": "^1.0.1",
     "@mangrovedao/mangrove-core": "^2.0.3",
-    "@mangrovedao/mangrove-deployments": "^2.0.1-1",
+    "@mangrovedao/mangrove-deployments": "^2.0.1-2",
     "@mangrovedao/mangrove-strats": "^2.0.0-b1.2",
     "@mangrovedao/reliable-event-subscriber": "1.1.29",
     "@types/object-inspect": "^1.8.1",

--- a/src/mangrove.ts
+++ b/src/mangrove.ts
@@ -1033,6 +1033,19 @@ class Mangrove {
       (logic) => logic.address.toLowerCase() === address.toLowerCase(),
     );
   }
+
+  /**
+   * Get the address of the router contract for resting orders belonging to `this.signer`, i.e, the connected user.
+   *
+   * This is the contract that will be transferring funds on behalf of the signer
+   * and will have to be approved to do so.
+   *
+   * @returns the address of the router contract for resting orders belonging to `this.signer`, i.e, the connected user.
+   */
+  async getRestingOrderRouterAddress(): Promise<string> {
+    const user = await this.signer.getAddress();
+    return await this.orderContract.router(user);
+  }
 }
 
 export default Mangrove;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,12 +1259,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mangrovedao/mangrove-deployments@npm:^2.0.1-1":
-  version: 2.0.1-1
-  resolution: "@mangrovedao/mangrove-deployments@npm:2.0.1-1"
+"@mangrovedao/mangrove-deployments@npm:^2.0.1-2":
+  version: 2.0.1-2
+  resolution: "@mangrovedao/mangrove-deployments@npm:2.0.1-2"
   dependencies:
     semver: ^7.5.4
-  checksum: 9572b7e9c381a196cf9460e677f7e255e344780954558595a8b4036b720caba74957208f8b9a1291ac2c5d6d8ab97e5675638e61f6c7eb25a6f22cda98182e45
+  checksum: 13a6efd3af8ced8f95e50dc6d70893b4bd294b969a1c69682a7d1377044455d5aa5875577e9f44536ba8a1e8f3986d2b138a9be97be959cc2309d588e5c9f7d5
   languageName: node
   linkType: hard
 
@@ -1289,7 +1289,7 @@ __metadata:
     "@ethersproject/providers": ^5.7.2
     "@mangrovedao/context-addresses": ^1.0.1
     "@mangrovedao/mangrove-core": ^2.0.3
-    "@mangrovedao/mangrove-deployments": ^2.0.1-1
+    "@mangrovedao/mangrove-deployments": ^2.0.1-2
     "@mangrovedao/mangrove-strats": ^2.0.0-b1.2
     "@mangrovedao/reliable-event-subscriber": 1.1.29
     "@typechain/ethers-v5": ^11.1.2


### PR DESCRIPTION
- feat: Add `Mangrove.getRestingOrderRouterAddress` which gets the address of the router contract for resting orders belonging to the connected user (`Mangrove.signer`).
- Upgrade to mangrove-deployments v2.0.1-2
