### PR TITLE
feat!: Rename Market.close to disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Next version
 
+- feat: Rename `Market.close()` to `Market.disconnect()` to more clearly signal that it's dual to `Market.connect()` and does not close the market on Mangrove.
 - Upgrade or remove `examples/how-tos` so they match the new version of the Mangrove core protocol and SDK
 
 # 2.0.5-3

--- a/src/market.ts
+++ b/src/market.ts
@@ -618,6 +618,22 @@ class Market {
   }
 
   /**
+   * Disconnect from a market.
+   */
+  disconnect() {
+    if (
+      !this.asksCb ||
+      !this.bidsCb ||
+      !this.#asksSemibook ||
+      !this.#bidsSemibook
+    ) {
+      throw Error("Market is not initialized");
+    }
+    this.#asksSemibook.removeEventListener(this.asksCb);
+    this.#bidsSemibook.removeEventListener(this.bidsCb);
+  }
+
+  /**
    * Initialize a new market.
    *
    * @param params A set of parameters identifying the `params.base`:`params.quote` market on Mangrove to connect to.
@@ -649,22 +665,6 @@ class Market {
       inbound_tkn: this.base.address,
       tickSpacing: this.tickSpacing,
     };
-  }
-
-  /**
-   * Close a Market instance.
-   */
-  public close() {
-    if (
-      !this.asksCb ||
-      !this.bidsCb ||
-      !this.#asksSemibook ||
-      !this.#bidsSemibook
-    ) {
-      throw Error("Market is not initialized");
-    }
-    this.#asksSemibook.removeEventListener(this.asksCb);
-    this.#bidsSemibook.removeEventListener(this.bidsCb);
   }
 
   /**

--- a/src/market.ts
+++ b/src/market.ts
@@ -547,35 +547,35 @@ class Market {
   tradeEventManagement: TradeEventManagement = new TradeEventManagement();
   prettyP = new PrettyPrint();
 
-  private asksCb: Semibook.EventListener | undefined;
-  private bidsCb: Semibook.EventListener | undefined;
+  #asksCb: Semibook.EventListener | undefined;
+  #bidsCb: Semibook.EventListener | undefined;
 
-  private minVolumeAskInternal(key: RouterLogic): Big.Big {
+  #minVolumeAskInternal(key: RouterLogic): Big.Big {
     const config = this.config();
     return config.asks.density.getRequiredOutboundForGasreq(
       config.asks.offer_gasbase + this.mgv.logics[key].gasOverhead,
     );
   }
 
-  private minVolumeBidInternal(key: RouterLogic): Big.Big {
+  #minVolumeBidInternal(key: RouterLogic): Big.Big {
     const config = this.config();
     return config.bids.density.getRequiredOutboundForGasreq(
       config.bids.offer_gasbase + this.mgv.logics[key].gasOverhead,
     );
   }
 
-  public get minVolumeAsk(): Market.MinVolume {
+  get minVolumeAsk(): Market.MinVolume {
     return Object.keys(this.mgv.logics).reduce((acc, _key) => {
       const key = _key as RouterLogic;
-      acc[key] = this.minVolumeAskInternal(key as RouterLogic);
+      acc[key] = this.#minVolumeAskInternal(key as RouterLogic);
       return acc;
     }, {} as Market.MinVolume);
   }
 
-  public get minVolumeBid(): Market.MinVolume {
+  get minVolumeBid(): Market.MinVolume {
     return Object.keys(this.mgv.logics).reduce((acc, _key) => {
       const key = _key as RouterLogic;
-      acc[key] = this.minVolumeBidInternal(key as RouterLogic);
+      acc[key] = this.#minVolumeBidInternal(key as RouterLogic);
       return acc;
     }, {} as Market.MinVolume);
   }
@@ -622,15 +622,15 @@ class Market {
    */
   disconnect() {
     if (
-      !this.asksCb ||
-      !this.bidsCb ||
+      !this.#asksCb ||
+      !this.#bidsCb ||
       !this.#asksSemibook ||
       !this.#bidsSemibook
     ) {
       throw Error("Market is not initialized");
     }
-    this.#asksSemibook.removeEventListener(this.asksCb);
-    this.#bidsSemibook.removeEventListener(this.bidsCb);
+    this.#asksSemibook.removeEventListener(this.#asksCb);
+    this.#bidsSemibook.removeEventListener(this.#bidsCb);
   }
 
   /**
@@ -712,18 +712,18 @@ class Market {
       }
     };
 
-    this.asksCb = this.#semibookEventCallback.bind(this);
+    this.#asksCb = this.#semibookEventCallback.bind(this);
     const asksPromise = Semibook.connect(
       this,
       "asks",
-      this.asksCb,
+      this.#asksCb,
       getSemibookOpts("asks"),
     );
-    this.bidsCb = this.#semibookEventCallback.bind(this);
+    this.#bidsCb = this.#semibookEventCallback.bind(this);
     const bidsPromise = Semibook.connect(
       this,
       "bids",
-      this.bidsCb,
+      this.#bidsCb,
       getSemibookOpts("bids"),
     );
     this.#asksSemibook = await asksPromise;

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -873,7 +873,7 @@ describe("Market integration tests suite", () => {
     assert.deepStrictEqual(latestAsks2, [offer1], "asks semibook not correct");
     assert.deepStrictEqual(latestBids2, [offer2], "bids semibook not correct");
 
-    market2.close();
+    market2.disconnect();
     await market.sell({ maxTick: bidTick, fillVolume: "1.3" });
 
     const offerFail = await queue.get();


### PR DESCRIPTION
Rename `Market.close()` to `Market.disconnect()` to more clearly signal that it's dual to `Market.connect()` and does not close the market on Mangrove.