### PR TITLE
fix: Make SimpleAaveLogic optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- fix: Make SimpleAaveLogic optional: If the address is not available on a network, the logic will not be available.
+
 # 2.0.5-11
 
 - Upgrade to context-addresses v1.1.4 (includes Blast Sepolia Multicall2 address)

--- a/src/amplifier/mangroveAmplifier.ts
+++ b/src/amplifier/mangroveAmplifier.ts
@@ -227,17 +227,11 @@ class MangroveAmplifier {
       fundOwner: ethers.constants.AddressZero,
     });
 
-    const logicKey = Object.entries(this.mgv.logics).filter(([key, value]) => {
-      if (value.address === logicAddress) {
-        return true;
-      }
-    });
+    const logicInstance = this.mgv.getLogicByAddress(logicAddress);
 
-    if (logicKey.length === 0) {
+    if (logicInstance === undefined) {
       throw new Error("No logic found for the given address");
     }
-
-    const logicInstance = (this.mgv.logics as any)[logicKey[0][0]];
 
     return logicInstance;
   }

--- a/src/logics/AbstractRoutingLogic.ts
+++ b/src/logics/AbstractRoutingLogic.ts
@@ -4,9 +4,16 @@ import { ethers } from "ethers";
 
 /**
  * Creates a dictionary of routing logics from a list of routing logics.
+ *
+ * Some routing logics may not be available on some networks, so they are optional.
  */
-export type IDsDictFromLogics<T extends AbstractRoutingLogic<any>> = {
-  [P in T as P["id"]]: P;
+export type IDsDictFromLogics<
+  TRequired extends AbstractRoutingLogic<any>,
+  TOptional extends AbstractRoutingLogic<any>,
+> = {
+  [P in TRequired as P["id"]]: P;
+} & {
+  [P in TOptional as P["id"]]: P | undefined;
 };
 
 /**

--- a/src/market.ts
+++ b/src/market.ts
@@ -552,15 +552,23 @@ class Market {
 
   #minVolumeAskInternal(key: RouterLogic): Big.Big {
     const config = this.config();
+    const logic = this.mgv.logics[key];
+    if (logic === undefined) {
+      throw new Error(`RouterLogic ${key} not found`);
+    }
     return config.asks.density.getRequiredOutboundForGasreq(
-      config.asks.offer_gasbase + this.mgv.logics[key].gasOverhead,
+      config.asks.offer_gasbase + logic.gasOverhead,
     );
   }
 
   #minVolumeBidInternal(key: RouterLogic): Big.Big {
     const config = this.config();
+    const logic = this.mgv.logics[key];
+    if (logic === undefined) {
+      throw new Error(`RouterLogic ${key} not found`);
+    }
     return config.bids.density.getRequiredOutboundForGasreq(
-      config.bids.offer_gasbase + this.mgv.logics[key].gasOverhead,
+      config.bids.offer_gasbase + logic.gasOverhead,
     );
   }
 

--- a/test/integration/market.integration.test.ts
+++ b/test/integration/market.integration.test.ts
@@ -1801,7 +1801,7 @@ describe("Market integration tests suite", () => {
       tickSpacing: 1,
     });
     const gasreqSimple = mgv.logics.simple.gasOverhead;
-    const gasreqAave = mgv.logics.aave.gasOverhead;
+    const gasreqAave = mgv.logics.aave!.gasOverhead;
 
     const baseAsOutbound = await mgv.readerContract.minVolume(
       market.olKeyBaseQuote,

--- a/test/integration/restingOrder.integration.test.ts
+++ b/test/integration/restingOrder.integration.test.ts
@@ -146,7 +146,7 @@ describe("RestingOrder", () => {
 
     it("should post a resting order using aave", async () => {
       // create a buy order (buy a with b)
-      const simpleAaveLogic = mgv.logics.aave.logic;
+      const simpleAaveLogic = mgv.logics.aave!.logic;
       const fundOwner = await mgv.signer.getAddress();
       const aTokenB = await Token.createTokenFromAddress(
         await simpleAaveLogic.overlying(tokenB.address),


### PR DESCRIPTION
`SimpleAaveLogic` is not available on Blast Sepolia, so mangrove.js threw an error when it tried to get the address and create the routing logic.

This PR therefore makes SimpleAaveLogic optional. If the address isn't found for a network, that routing logic isn't available.