### PR TITLE
feat(kandel): Add defaults for minimum{Base,Quote}PerOfferFactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next version
 
+- Add defaults for `minimum{Base,Quote}PerOfferFactor` in the Kandel configuration
+- Add initial configuration for Blast and Blast Sepolia. For now, they use the defaults, so have only be added to make it easy to find and modify later if needed.
+
 # 2.0.5-14
 
 - fix: Handle missing case where AaveKandel was assumed available

--- a/src/constants/kandelConfiguration.json
+++ b/src/constants/kandelConfiguration.json
@@ -77,6 +77,29 @@
         }
       }
     },
+    "blast-sepolia": {
+      "minimumBasePerOfferFactor": 10,
+      "minimumQuotePerOfferFactor": 10,
+      "aaveEnabled": false,
+      "markets": {
+        "WETH.e": {
+          "USDB.e": {
+            "1": {}
+          }
+        },
+        "WBTC.T/MGV": {
+          "USDB.e": {
+            "1": {}
+          }
+        }
+      }
+    },
+    "blast": {
+      "minimumBasePerOfferFactor": 10,
+      "minimumQuotePerOfferFactor": 10,
+      "aaveEnabled": false,
+      "markets": {}
+    },
     "local": {
       "markets": {
         "TokenA": {

--- a/src/constants/kandelConfiguration.json
+++ b/src/constants/kandelConfiguration.json
@@ -1,5 +1,7 @@
 {
   "gaspriceFactor": 10,
+  "minimumBasePerOfferFactor": 10,
+  "minimumQuotePerOfferFactor": 10,
   "maxOffersInPopulateChunk": 198,
   "maxOffersInRetractChunk": 198,
   "aaveEnabled": false,

--- a/test/unit/kandel/kandelConfiguration.unit.test.ts
+++ b/test/unit/kandel/kandelConfiguration.unit.test.ts
@@ -36,8 +36,17 @@ describe(`${KandelConfiguration.prototype.constructor.name} unit tests suite`, (
                   baseQuoteTickOffset: undefined,
                 },
               },
-              FailingConfig1: { "1": {} },
-              FailingConfig2: { "2": { minimumBasePerOfferFactor: 1 } },
+              FailingConfig1: {
+                "1": {
+                  minimumBasePerOfferFactor: undefined,
+                },
+              },
+              FailingConfig2: {
+                "2": {
+                  minimumQuotePerOfferFactor: undefined,
+                  minimumBasePerOfferFactor: 1,
+                },
+              },
               FailingConfig3: {
                 "3": {
                   minimumBasePerOfferFactor: 1,


### PR DESCRIPTION
This will prevent the SDK from breaking when used on a market for which there is not Kandel configuration.
The values may not be ideal, but the user can override if needed.

Also add initial configuration for Blast and Blast Sepolia. For now, they use the defaults, so have only be added to make it easy to find and modify later if needed.