### PR TITLE
feat: Move Transaction type from Market to util/transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Move `Transaction` type from `Market` to `util/transactions`. Also, use this type in `MangroveAmplifier` instead of the duplicated type in that file.
+
 # 2.0.5-42
 
 - Upgrade to mangrove-strats v2.1.0-4 (includes deployed Blast contract versions)

--- a/src/amplifier/mangroveAmplifier.ts
+++ b/src/amplifier/mangroveAmplifier.ts
@@ -2,17 +2,14 @@ import Mangrove from "../mangrove";
 import { typechain } from "../types";
 import { BigNumber, ethers } from "ethers";
 import logger from "../util/logger";
-import { createTxWithOptionalGasEstimation } from "../util/transactions";
+import {
+  createTxWithOptionalGasEstimation,
+  Transaction,
+} from "../util/transactions";
 import { AbstractRoutingLogic } from "../logics/AbstractRoutingLogic";
 import { z } from "zod";
 import { evmAddress, liberalBigInt, liberalPositiveBigInt } from "../schemas";
 import { OLKeyStruct } from "../types/typechain/MangroveAmplifier";
-
-export type Transaction<TResult> = {
-  result: Promise<TResult>;
-  /** The low-level transaction that has been submitted to the chain. */
-  response: Promise<ethers.ContractTransaction>;
-};
 
 const inboundTokenSchema = z.object({
   inboundToken: evmAddress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import KandelStrategies from "./kandelStrategies";
 import * as mgvTestUtil from "./util/test/mgvIntegrationTestUtil";
 import { typechain } from "./types";
 import { Bigish } from "./util";
+import { Transaction } from "./util/transactions";
 import KandelDistribution, {
   OfferDistribution,
   OfferList,
@@ -103,6 +104,7 @@ export { Mangrove, Market, Semibook, OfferLogic, LiquidityProvider };
 // Utils
 export type { prettyPrintFilter };
 export type { Bigish };
+export type { Transaction };
 export type { Optional };
 export type { JsonWalletOptions };
 export type { MangroveEventSubscriber };

--- a/src/kandel/kandelSeeder.ts
+++ b/src/kandel/kandelSeeder.ts
@@ -3,6 +3,7 @@ import Mangrove from "../mangrove";
 import { typechain } from "../types";
 
 import TradeEventManagement from "../util/tradeEventManagement";
+import { Transaction } from "../util/transactions";
 
 import Market from "../market";
 import KandelDistribution from "./kandelDistribution";
@@ -63,7 +64,7 @@ class KandelSeeder {
   public async sow(
     seed: KandelSeed,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<GeometricKandelInstance>> {
+  ): Promise<Transaction<GeometricKandelInstance>> {
     if (seed.liquiditySharing && !seed.onAave) {
       throw Error(
         "Liquidity sharing is only supported for AaveKandel instances.",

--- a/src/market.ts
+++ b/src/market.ts
@@ -5,6 +5,7 @@ import Token, { TokenCalculations } from "./token";
 import Semibook from "./semibook";
 import { typechain } from "./types";
 import { Bigish } from "./util";
+import { Transaction } from "./util/transactions";
 import Trade from "./util/trade";
 import * as TCM from "./types/typechain/Mangrove";
 import TradeEventManagement from "./util/tradeEventManagement";
@@ -192,25 +193,6 @@ namespace Market {
    * No data is returned, but the transaction may fail.
    */
   export type RetractRestingOrderResult = void;
-
-  /**
-   * A transaction that has been submitted to a market.
-   *
-   * Market operations return this type so that the caller can track the state of the
-   * low-level transaction that has been submitted as well as the result of the market operation.
-   */
-  export type Transaction<TResult> = {
-    /** The result of the market transaction.
-     *
-     * Resolves when the transaction has been included on-chain.
-     *
-     * Rejects if the transaction fails.
-     */
-    result: Promise<TResult>;
-
-    /** The low-level transaction that has been submitted to the chain. */
-    response: Promise<ethers.ContractTransaction>;
-  };
 
   export type OrderRoute = "Mangrove" | "MangroveOrder";
 
@@ -1033,7 +1015,7 @@ class Market {
   buy(
     params: Market.TradeParams,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.OrderResult>> {
+  ): Promise<Transaction<Market.OrderResult>> {
     return this.trade.order("buy", params, this, overrides);
   }
 
@@ -1060,7 +1042,7 @@ class Market {
   sell(
     params: Market.TradeParams,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.OrderResult>> {
+  ): Promise<Transaction<Market.OrderResult>> {
     return this.trade.order("sell", params, this, overrides);
   }
 
@@ -1097,7 +1079,7 @@ class Market {
     ba: Market.BA,
     params: Market.UpdateRestingOrderParams,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.UpdateRestingOrderResult>> {
+  ): Promise<Transaction<Market.UpdateRestingOrderResult>> {
     return this.trade.updateRestingOrder(this, ba, params, overrides);
   }
 
@@ -1113,7 +1095,7 @@ class Market {
     id: number,
     deprovision = false,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.RetractRestingOrderResult>> {
+  ): Promise<Transaction<Market.RetractRestingOrderResult>> {
     return this.trade.retractRestingOrder(this, ba, id, deprovision, overrides);
   }
 
@@ -1528,7 +1510,7 @@ class Market {
       offerId: number;
     },
     overrides?: ethers.Overrides,
-  ): Promise<Market.Transaction<boolean>> {
+  ): Promise<Transaction<boolean>> {
     const user = await this.mgv.signer.getAddress();
     const router = await this.mgv.orderContract.router(user);
     const olKeyHash = this.mgv.getOlKeyHash(this.getOLKey(params.ba));

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -9,6 +9,7 @@ import TradeEventManagement, {
 import configuration from "../configuration";
 import TickPriceHelper from "./tickPriceHelper";
 import { AbstractRoutingLogic } from "../logics/AbstractRoutingLogic";
+import { Transaction } from "./transactions";
 
 export type CleanUnitParams = {
   ba: Market.BA;
@@ -224,7 +225,7 @@ class Trade {
     params: Market.TradeParams,
     market: Market,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.OrderResult>> {
+  ): Promise<Transaction<Market.OrderResult>> {
     const { maxTick, fillVolume, fillWants, restingOrderParams, orderType } =
       this.getRawParams(bs, params, market);
     switch (orderType) {
@@ -275,7 +276,7 @@ class Trade {
     ba: Market.BA,
     params: Market.UpdateRestingOrderParams,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.UpdateRestingOrderResult>> {
+  ): Promise<Transaction<Market.UpdateRestingOrderResult>> {
     const olKey = market.getOLKey(ba);
 
     const restingOrderParams = await this.getRestingOrderParams(
@@ -401,7 +402,7 @@ class Trade {
     id: number,
     deprovision = false,
     overrides: ethers.Overrides = {},
-  ): Promise<Market.Transaction<Market.RetractRestingOrderResult>> {
+  ): Promise<Transaction<Market.RetractRestingOrderResult>> {
     const olKey = market.getOLKey(ba);
 
     let txPromise: Promise<ethers.ContractTransaction> | undefined = undefined;
@@ -590,7 +591,7 @@ class Trade {
       gasLowerBound: ethers.BigNumberish;
     },
     overrides: ethers.Overrides,
-  ): Promise<Market.Transaction<Market.OrderResult>> {
+  ): Promise<Transaction<Market.OrderResult>> {
     const olKey = market.getOLKey(this.bsToBa(orderType));
     orderType === "buy"
       ? [market.base, market.quote]
@@ -724,7 +725,7 @@ class Trade {
       takerWantsLogic: AbstractRoutingLogic;
     },
     overrides: ethers.Overrides,
-  ): Promise<Market.Transaction<Market.OrderResult>> {
+  ): Promise<Transaction<Market.OrderResult>> {
     const ba = this.bsToBa(orderType);
     const restingOrderParams = restingParams
       ? await this.getRestingOrderParams(restingParams, market, ba)

--- a/src/util/transactions.ts
+++ b/src/util/transactions.ts
@@ -20,3 +20,22 @@ export const createTxWithOptionalGasEstimation = async <T extends any[]>(
 
   return await createTx(...args);
 };
+
+/**
+ * A transaction that has been submitted and which (once included in a block) returns a result.
+ *
+ * Operations return this type so that the caller can track the state of the
+ * low-level transaction that has been submitted as well as the result of the operation.
+ */
+export type Transaction<TResult> = {
+  /** The result of the transaction.
+   *
+   * Resolves when the transaction has been included on-chain.
+   *
+   * Rejects if the transaction fails.
+   */
+  result: Promise<TResult>;
+
+  /** The low-level transaction that has been submitted to the chain. */
+  response: Promise<ethers.ContractTransaction>;
+};


### PR DESCRIPTION
Also fixes the doc generation issue of `MangroveAmplifier` referencing a type that is not included in the docs.